### PR TITLE
Rework trade actions

### DIFF
--- a/app/pods/components/contextual-menu/component.ts
+++ b/app/pods/components/contextual-menu/component.ts
@@ -1,0 +1,22 @@
+// Vendor
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+import fade from 'ember-animated/transitions/fade';
+
+export default class ContextualMenu extends Component {
+  @tracked
+  itemsAreVisible: boolean = false;
+
+  fadeTransition = fade;
+
+  @action
+  showItems() {
+    this.itemsAreVisible = true;
+  }
+
+  @action
+  hideItems() {
+    this.itemsAreVisible = false;
+  }
+}

--- a/app/pods/components/contextual-menu/item/component.ts
+++ b/app/pods/components/contextual-menu/item/component.ts
@@ -1,0 +1,9 @@
+// Vendor
+import Component from '@glimmer/component';
+
+interface Args {
+  label: string;
+  onClick?: () => {};
+}
+
+export default class ContextualMenuItem extends Component<Args> {}

--- a/app/pods/components/contextual-menu/item/component.ts
+++ b/app/pods/components/contextual-menu/item/component.ts
@@ -1,6 +1,6 @@
 // Vendor
 import Component from '@glimmer/component';
-import {action} from "@ember/object";
+import {action} from '@ember/object';
 
 interface Args {
   label: string;

--- a/app/pods/components/contextual-menu/item/component.ts
+++ b/app/pods/components/contextual-menu/item/component.ts
@@ -1,9 +1,17 @@
 // Vendor
 import Component from '@glimmer/component';
+import {action} from "@ember/object";
 
 interface Args {
   label: string;
-  onClick?: () => {};
+  onClick: () => Promise<any> | void;
+  didClick: () => {};
 }
 
-export default class ContextualMenuItem extends Component<Args> {}
+export default class ContextualMenuItem extends Component<Args> {
+  @action
+  async dispatchAction() {
+    await this.args.onClick();
+    this.args.didClick();
+  }
+}

--- a/app/pods/components/contextual-menu/item/styles.module.scss
+++ b/app/pods/components/contextual-menu/item/styles.module.scss
@@ -1,9 +1,12 @@
 .item {
+  text-align: left;
   display: block;
+  width: 100%;
   border: 0;
   background: none;
   color: $white;
   transition: color 0.2s ease;
+  white-space: nowrap;
 
   &:hover,
   &:focus {

--- a/app/pods/components/contextual-menu/item/styles.module.scss
+++ b/app/pods/components/contextual-menu/item/styles.module.scss
@@ -1,12 +1,12 @@
 .item {
-  text-align: left;
   display: block;
   width: 100%;
   border: 0;
   background: none;
+  text-align: left;
+  white-space: nowrap;
   color: $white;
   transition: color 0.2s ease;
-  white-space: nowrap;
 
   &:hover,
   &:focus {

--- a/app/pods/components/contextual-menu/item/styles.module.scss
+++ b/app/pods/components/contextual-menu/item/styles.module.scss
@@ -1,0 +1,12 @@
+.item {
+  display: block;
+  border: 0;
+  background: none;
+  color: $white;
+  transition: color 0.2s ease;
+
+  &:hover,
+  &:focus {
+    color: #cbcbcb;
+  }
+}

--- a/app/pods/components/contextual-menu/item/template.hbs
+++ b/app/pods/components/contextual-menu/item/template.hbs
@@ -1,0 +1,7 @@
+<button
+  {{on "click" (fn @onClick)}}
+  type="button"
+  local-class="item"
+>
+  {{@label}}
+</button>

--- a/app/pods/components/contextual-menu/item/template.hbs
+++ b/app/pods/components/contextual-menu/item/template.hbs
@@ -1,5 +1,5 @@
 <button
-  {{on "click" (fn @onClick)}}
+  {{on "click" (fn this.dispatchAction)}}
   type="button"
   local-class="item"
 >

--- a/app/pods/components/contextual-menu/styles.module.scss
+++ b/app/pods/components/contextual-menu/styles.module.scss
@@ -10,9 +10,10 @@
 .items {
   position: absolute;
   z-index: 2;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
   right: 0;
-  padding: 5px;
+  padding: 5px 20px 5px 5px;
   border: 1px solid $gray-alt;
   background-color: $gray;
 }

--- a/app/pods/components/contextual-menu/styles.module.scss
+++ b/app/pods/components/contextual-menu/styles.module.scss
@@ -1,0 +1,18 @@
+.contextual-menu {
+  position: relative;
+}
+
+.trigger {
+  z-index: 1;
+  cursor: pointer;
+}
+
+.items {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  right: 0;
+  padding: 5px;
+  border: 1px solid $gray-alt;
+  background-color: $gray;
+}

--- a/app/pods/components/contextual-menu/styles.module.scss
+++ b/app/pods/components/contextual-menu/styles.module.scss
@@ -11,8 +11,8 @@
   position: absolute;
   z-index: 2;
   top: 50%;
-  transform: translateY(-50%);
   right: 0;
+  transform: translateY(-50%);
   padding: 5px 20px 5px 5px;
   border: 1px solid $gray-alt;
   background-color: $gray;

--- a/app/pods/components/contextual-menu/template.hbs
+++ b/app/pods/components/contextual-menu/template.hbs
@@ -1,0 +1,14 @@
+<div local-class="contextual-menu" ...attributes>
+  <div
+    {{on "click" (fn this.showItems)}}
+    local-class="trigger"
+  >
+    <FaIcon @icon="ellipsis-h" />
+  </div>
+
+  {{#animated-if this.itemsAreVisible use=this.fadeTransition duration=200}}
+    <div local-class="items" {{on "mouseleave" (fn this.hideItems)}}>
+      {{yield (component "contextual-menu/item")}}
+    </div>
+  {{/animated-if}}
+</div>

--- a/app/pods/components/contextual-menu/template.hbs
+++ b/app/pods/components/contextual-menu/template.hbs
@@ -6,9 +6,13 @@
     <FaIcon @icon="ellipsis-h" />
   </div>
 
-  {{#animated-if this.itemsAreVisible use=this.fadeTransition duration=200}}
+  {{#animated-if
+    this.itemsAreVisible
+    use=this.fadeTransition
+    duration=200
+  }}
     <div local-class="items" {{on "mouseleave" (fn this.hideItems)}}>
-      {{yield (component "contextual-menu/item")}}
+      {{yield (component "contextual-menu/item" didClick=(fn this.hideItems))}}
     </div>
   {{/animated-if}}
 </div>

--- a/app/pods/components/page/bookmarks/folder/component.ts
+++ b/app/pods/components/page/bookmarks/folder/component.ts
@@ -44,7 +44,7 @@ export default class BookmarksFolder extends Component<Args> {
   isStagedForDeletion: boolean;
 
   @tracked
-  isExpanded: boolean = this.bookmarks.isFolderExpanded(this.args.folder.id);
+  isExpanded: boolean = false;
 
   @tracked
   isLoaded: boolean = false;
@@ -71,9 +71,21 @@ export default class BookmarksFolder extends Component<Args> {
   }
 
   @dropTask
-  *refreshTradesTask() {
-    if (!this.isExpanded) return;
+  *initialSetupTask() {
+    if (!this.bookmarks.isFolderExpanded(this.args.folder.id)) return;
 
+    this.isAnimating = true;
+    this.isExpanded = true;
+
+    yield performTask(this.refreshTradesTask);
+
+    yield timeout(EXPANSION_ANIMATION_DURATION_IN_MILLISECONDS);
+
+    this.isAnimating = false;
+  }
+
+  @dropTask
+  *refreshTradesTask() {
     this.trades = yield this.bookmarks.fetchTradesByFolderId(this.args.folder.id);
     this.isLoaded = true;
   }
@@ -128,6 +140,7 @@ export default class BookmarksFolder extends Component<Args> {
   *toggleExpansionTask() {
     this.isAnimating = true;
     this.isExpanded = this.bookmarks.toggleFolderExpansion(this.args.folder.id);
+
     yield performTask(this.refreshTradesTask);
 
     yield timeout(EXPANSION_ANIMATION_DURATION_IN_MILLISECONDS);

--- a/app/pods/components/page/bookmarks/folder/component.ts
+++ b/app/pods/components/page/bookmarks/folder/component.ts
@@ -81,7 +81,7 @@ export default class BookmarksFolder extends Component<Args> {
   @dropTask
   *deleteTradeTask(deletingTrade: BookmarksTradeStruct) {
     yield this.bookmarks.deleteTrade(deletingTrade);
-    this.trades = yield this.bookmarks.fetchTradesByFolderId(this.args.folder.id);
+    this.trades = yield performTask(this.refreshTradesTask);
     this.stagedDeletingTrade = null;
   }
 
@@ -95,7 +95,7 @@ export default class BookmarksFolder extends Component<Args> {
   @dropTask
   *persistTradeTask(trade: BookmarksTradeStruct) {
     yield this.bookmarks.persistTrade(trade);
-    this.trades = yield this.bookmarks.fetchTradesByFolderId(this.args.folder.id);
+    this.trades = yield performTask(this.refreshTradesTask);
     this.stagedTrade = null;
   }
 
@@ -111,7 +111,17 @@ export default class BookmarksFolder extends Component<Args> {
       }
     });
 
-    this.trades = yield this.bookmarks.fetchTradesByFolderId(this.args.folder.id);
+    yield performTask(this.refreshTradesTask);
+  }
+
+  @dropTask
+  *toggleTradeCompletionTask(trade: BookmarksTradeStruct) {
+    yield this.bookmarks.persistTrade({
+      ...trade,
+      completedAt: trade.completedAt ? null : new Date().toUTCString()
+    });
+
+    yield performTask(this.refreshTradesTask);
   }
 
   @dropTask

--- a/app/pods/components/page/bookmarks/folder/styles.module.scss
+++ b/app/pods/components/page/bookmarks/folder/styles.module.scss
@@ -69,7 +69,11 @@
 }
 
 .body {
-  overflow: hidden;
+  overflow: visible;
+
+  .is-animating {
+    overflow: hidden;
+  }
 }
 
 .trades {
@@ -77,6 +81,10 @@
   border-top: 1px solid $blue-alt;
   margin: 0;
   list-style: none;
+
+  &.is-reordering {
+    overflow: hidden;
+  }
 }
 
 .trade {

--- a/app/pods/components/page/bookmarks/folder/styles.module.scss
+++ b/app/pods/components/page/bookmarks/folder/styles.module.scss
@@ -6,16 +6,6 @@
       transform: rotate(180deg);
     }
   }
-
-  &:hover {
-    .header-actions {
-      opacity: 1;
-    }
-
-    .expansion-indicator {
-      opacity: 1;
-    }
-  }
 }
 
 .expansion-wrapper {
@@ -27,11 +17,9 @@
 }
 
 .expansion-indicator {
-  opacity: 0;
   transform: rotate(0deg);
   align-items: center;
-  transition: 0.2s ease;
-  transition-property: transform, opacity;
+  transition: transform 0.2s ease;
 }
 
 .header {
@@ -68,9 +56,7 @@
 
 .header-actions {
   display: flex;
-  opacity: 0;
   align-items: center;
-  transition: opacity 0.2s ease;
 }
 
 .header-action {
@@ -96,17 +82,10 @@
 .trade {
   display: flex;
   position: relative;
-  z-index: 0;
   align-items: center;
   border-bottom: 1px solid rgba($blue-alt, 0.4);
   background-color: transparent;
   transition: background-color 0.2s ease;
-
-  &:hover {
-    .trade-actions {
-      opacity: 1;
-    }
-  }
 
   &:global(.is-dragging) {
     z-index: 1;
@@ -144,15 +123,14 @@
 }
 
 .trade-actions {
-  opacity: 0;
+  display: flex;
   padding-right: 2px;
-  transition: opacity 0.2s ease;
 }
 
 .trade-action {
   padding: 0;
   border: 0;
-  margin-right: 5px;
+  margin-right: 10px;
   background-color: transparent;
   outline: none;
   color: rgba($white, 0.8);

--- a/app/pods/components/page/bookmarks/folder/styles.module.scss
+++ b/app/pods/components/page/bookmarks/folder/styles.module.scss
@@ -71,7 +71,7 @@
 .body {
   overflow: visible;
 
-  .is-animating {
+  &.is-animating {
     overflow: hidden;
   }
 }

--- a/app/pods/components/page/bookmarks/folder/styles.module.scss
+++ b/app/pods/components/page/bookmarks/folder/styles.module.scss
@@ -130,6 +130,11 @@
   }
 }
 
+.trade-link-completed {
+  margin-right: 3px;
+  font-size: 9px;
+}
+
 .trade-actions {
   display: flex;
   padding-right: 2px;

--- a/app/pods/components/page/bookmarks/folder/template.hbs
+++ b/app/pods/components/page/bookmarks/folder/template.hbs
@@ -30,7 +30,7 @@
         type="button"
         local-class="header-action"
       }}
-        <FaIcon @icon="bars" />
+        <FaIcon @icon="sort" />
       {{/component}}
     </div>
   </div>
@@ -65,21 +65,16 @@
               </div>
 
               <div local-class="trade-actions">
-                <button
-                  {{on "click" (fn this.editTrade trade)}}
-                  type="button"
-                  local-class="trade-action"
-                >
-                  <FaIcon @icon="pen" />
-                </button>
-
-                <button
-                  {{on "click" (fn this.deleteTrade trade)}}
-                  type="button"
-                  local-class="trade-action"
-                >
-                  <FaIcon @icon="trash-alt" />
-                </button>
+                <ContextualMenu local-class="trade-action" as |MenuItem|>
+                  <MenuItem
+                    @label={{t "bookmarks.folder.edit-trade"}}
+                    @onClick={{fn this.editTrade trade}}
+                  />
+                  <MenuItem
+                    @label={{t "bookmarks.folder.delete-trade"}}
+                    @onClick={{fn this.deleteTrade trade}}
+                  />
+                </ContextualMenu>
 
                 {{#component
                   dragItem.handle
@@ -87,7 +82,7 @@
                   type="button"
                   local-class="trade-action"
                 }}
-                  <FaIcon @icon="bars" />
+                  <FaIcon @icon="sort"/>
                 {{/component}}
               </div>
             {{/component}}

--- a/app/pods/components/page/bookmarks/folder/template.hbs
+++ b/app/pods/components/page/bookmarks/folder/template.hbs
@@ -1,5 +1,5 @@
 <div
-  {{did-insert (perform this.refreshTradesTask)}}
+  {{did-insert (perform this.initialSetupTask)}}
   local-class="container {{if this.isExpanded "is-expanded"}}"
   ...attributes
 >

--- a/app/pods/components/page/bookmarks/folder/template.hbs
+++ b/app/pods/components/page/bookmarks/folder/template.hbs
@@ -79,7 +79,11 @@
                     @onClick={{perform this.updateTradeLocationTask trade}}
                   />
                   <MenuItem
-                    @label={{t (if trade.completedAt "bookmarks.folder.uncomplete-trade" "bookmarks.folder.complete-trade")}}
+                    @label={{if
+                      trade.completedAt
+                      (t "bookmarks.folder.uncomplete-trade")
+                      (t "bookmarks.folder.complete-trade")
+                    }}
                     @onClick={{perform this.toggleTradeCompletionTask trade}}
                   />
                   <MenuItem

--- a/app/pods/components/page/bookmarks/folder/template.hbs
+++ b/app/pods/components/page/bookmarks/folder/template.hbs
@@ -5,7 +5,7 @@
 >
   <div local-class="header">
     <div
-      {{on "click" (fn this.toggleExpansion)}}
+      {{on "click" (perform this.toggleExpansionTask)}}
       local-class="expansion-wrapper"
     >
       {{#if @folder.icon}}
@@ -35,7 +35,7 @@
     </div>
   </div>
 
-  <div local-class="body">
+  <div local-class="body {{if this.isAnimating "is-animating"}}">
     <AnimatedContainer>
       {{#animated-if
         (and this.isExpanded this.isLoaded)
@@ -43,7 +43,7 @@
         duration=200
       }}
         <SortableGroup
-          local-class="trades"
+          local-class="trades {{if this.isReorderingTrades "is-reordering"}}"
           @tagName="ul"
           @model={{this.trades}}
           @onChange={{perform this.reorderTradesTask}}
@@ -55,6 +55,8 @@
               local-class="trade"
               tagName="li"
               model=trade
+              onDragStart=(fn this.startTradesReordering)
+              onDragStop=(fn this.stopTradesReordering)
             as |dragItem|
             }}
               <div
@@ -66,6 +68,10 @@
 
               <div local-class="trade-actions">
                 <ContextualMenu local-class="trade-action" as |MenuItem|>
+                  <MenuItem
+                    @label={{t "bookmarks.folder.update-trade-location"}}
+                    @onClick={{perform this.updateTradeLocationTask trade}}
+                  />
                   <MenuItem
                     @label={{t "bookmarks.folder.edit-trade"}}
                     @onClick={{fn this.editTrade trade}}

--- a/app/pods/components/page/bookmarks/folder/template.hbs
+++ b/app/pods/components/page/bookmarks/folder/template.hbs
@@ -63,6 +63,12 @@
                 {{on "click" (fn this.navigateToTrade trade)}}
                 local-class="trade-link"
               >
+                {{#if trade.completedAt}}
+                  <span local-class="trade-link-completed">
+                    <FaIcon @icon="check"  />
+                  </span>
+                {{/if}}
+
                 {{trade.title}}
               </div>
 
@@ -71,6 +77,10 @@
                   <MenuItem
                     @label={{t "bookmarks.folder.update-trade-location"}}
                     @onClick={{perform this.updateTradeLocationTask trade}}
+                  />
+                  <MenuItem
+                    @label={{t (if trade.completedAt "bookmarks.folder.uncomplete-trade" "bookmarks.folder.complete-trade")}}
+                    @onClick={{perform this.toggleTradeCompletionTask trade}}
                   />
                   <MenuItem
                     @label={{t "bookmarks.folder.edit-trade"}}

--- a/app/pods/components/page/bookmarks/styles.module.scss
+++ b/app/pods/components/page/bookmarks/styles.module.scss
@@ -8,7 +8,6 @@
 
 .folder-wrapper {
   position: relative;
-  z-index: 0;
   padding: 5px 0;
 
   .folder {

--- a/app/services/bookmarks.ts
+++ b/app/services/bookmarks.ts
@@ -78,6 +78,7 @@ export default class Bookmarks extends Service {
       location,
       folderId,
       title: '',
+      completedAt: null,
       rank
     };
   }

--- a/app/services/dexie.ts
+++ b/app/services/dexie.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/promise-function-async,@typescript-eslint/no-misused-promises */
+
 // Vendor
 import Service from '@ember/service';
 import Dexie from 'dexie';
@@ -12,8 +14,22 @@ export default class DexieService extends Service {
 
     this.db.version(1).stores({
       bookmarkFolders: '++id,title,icon,rank',
-      bookmarkTrades: '++id,title,location,rank,folderId'
+      bookmarkTrades: '++id,title,rank,folderId'
     });
+
+    this.db
+      .version(2)
+      .stores({
+        bookmarkTrades: '++id,title,rank,folderId,completedAt'
+      })
+      .upgrade((transaction: Dexie.Transaction) => {
+        return transaction
+          .table('bookmarkTrades')
+          .toCollection()
+          .modify(bookmarkTrade => {
+            bookmarkTrade.completedAt = null;
+          });
+      });
   }
 
   async fetch<T>(table: TableName, id: number): Promise<T | null> {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -7,6 +7,8 @@ $extension-width: 400px;
 
 // Colors
 $black: #161616;
+$gray: #3f3f3f;
+$gray-alt: #616161;
 $white: #fff;
 $beige: #fff8e1;
 $blue: #0f304d;

--- a/app/types/bookmarks.ts
+++ b/app/types/bookmarks.ts
@@ -9,6 +9,7 @@ export interface BookmarksTradeStruct {
   location: BookmarksTradeLocation;
   rank: number;
   folderId: number;
+  completedAt: string | null;
 }
 
 export interface BookmarksFolderStruct {

--- a/config/environment.js
+++ b/config/environment.js
@@ -40,9 +40,9 @@ module.exports = function(environment) {
         'check',
         'times',
         'pen',
-        'bars',
-        'exclamation-circle',
-        'info-circle'
+        'info-circle',
+        'ellipsis-h',
+        'sort'
       ],
       'free-brands-svg-icons': ['github', 'discord']
     }

--- a/translations/bookmarks/en.yaml
+++ b/translations/bookmarks/en.yaml
@@ -4,6 +4,8 @@ bookmarks:
     edit-trade: Edit
     delete-trade: Delete
     update-trade-location: Save active trade
+    complete-trade: Mark as complete
+    uncomplete-trade: Unmark as complete
     trade-deletion:
       title: Confirm deletion
       confirmation: 'Delete the bookmark <strong>{name}</strong> ?'

--- a/translations/bookmarks/en.yaml
+++ b/translations/bookmarks/en.yaml
@@ -1,6 +1,8 @@
 bookmarks:
   folder:
     create-trade: Register current trade
+    edit-trade: Edit
+    delete-trade: Delete
     trade-deletion:
       title: Confirm deletion
       confirmation: 'Delete the bookmark <strong>{name}</strong> ?'
@@ -12,7 +14,6 @@ bookmarks:
       delete: Delete
       cancel: Cancel
   folder-edition:
-
     title: Bookmark folder
     save: Save
     fields:

--- a/translations/bookmarks/en.yaml
+++ b/translations/bookmarks/en.yaml
@@ -3,6 +3,7 @@ bookmarks:
     create-trade: Register current trade
     edit-trade: Edit
     delete-trade: Delete
+    update-trade-location: Save active trade
     trade-deletion:
       title: Confirm deletion
       confirmation: 'Delete the bookmark <strong>{name}</strong> ?'


### PR DESCRIPTION
### 👨‍💻 Feature

Rework trade bookmarks action.

Instead of having inline icons to represent available actions (edit, delete, reorder), we introduce a contextual menu that will makes it easier to add new actions.

Introduce 2 new features:
- Save active trade (replace the trade's location with the active one, perfect to tweaking trade queries)
- Mark a complete (toggles a ✔️ besides the title)

### 👀 Preview

![image](https://user-images.githubusercontent.com/4255460/76274309-abf6a900-6256-11ea-8342-580d475790df.png)

### 🤖 Beep beep bop

resolves https://github.com/exile-center/better-trading/issues/3
resolves https://github.com/exile-center/better-trading/issues/9