### PR TITLE
Introduce a collapse button for the side panel

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,8 +4,11 @@ import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 // Initialize the extension root container
+const isCollapsed = Boolean(window.localStorage.getItem('bt-side-panel-collapsed'));
 const extensionContainer = document.createElement('div');
 extensionContainer.id = 'better-trading-container';
+document.body.classList.add('bt-body');
+if (isCollapsed) document.body.classList.add('bt-is-collapsed');
 document.body.appendChild(extensionContainer);
 
 const {modulePrefix, podModulePrefix} = config;

--- a/app/helpers/trade-url.ts
+++ b/app/helpers/trade-url.ts
@@ -11,7 +11,7 @@ export default class TradeUrl extends Helper {
 
   compute(params: string[]) {
     const [type, slug, suffix] = params;
-    const tradeURL = this.location.getTradeURL(type, slug);
+    const tradeURL = this.location.getTradeUrl(type, slug);
 
     if (!suffix) return tradeURL;
 

--- a/app/pods/components/header/component.ts
+++ b/app/pods/components/header/component.ts
@@ -1,0 +1,30 @@
+// Vendor
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
+
+// Types
+import LocalStorage from 'better-trading/services/local-storage';
+
+export default class Header extends Component {
+  @service('local-storage')
+  localStorage: LocalStorage;
+
+  @tracked
+  expandButtonIsVisible: boolean = Boolean(this.localStorage.getValue('side-panel-collapsed'));
+
+  @action
+  collapse() {
+    this.localStorage.setValue('side-panel-collapsed', 'true');
+    document.body.classList.add('bt-is-collapsed');
+    this.expandButtonIsVisible = true;
+  }
+
+  @action
+  expand() {
+    this.localStorage.delete('side-panel-collapsed');
+    document.body.classList.remove('bt-is-collapsed');
+    this.expandButtonIsVisible = false;
+  }
+}

--- a/app/pods/components/header/styles.module.scss
+++ b/app/pods/components/header/styles.module.scss
@@ -33,7 +33,16 @@
   color: $white;
 }
 
-.navigation-item {
+.header-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 25px;
+  height: 25px;
+  padding: 0;
+  border: 0;
+  margin: 0;
+  background: transparent;
   font-size: 22px;
   color: $white;
   transition: color 0.2s ease;
@@ -42,4 +51,41 @@
   &:focus {
     color: rgba($white, 0.8);
   }
+}
+
+.expand-button {
+  display: flex;
+  position: fixed;
+  top: 50px;
+  right: 0;
+  opacity: 0;
+  align-items: center;
+  padding: 5px 10px;
+  border: 1px solid $blue-alt;
+  background-color: $blue;
+  outline: none;
+  font-size: 20px;
+  color: $white;
+  transition: opacity 0.2s ease;
+  border-right-width: 0;
+  pointer-events: none;
+
+  &:hover,
+  &:focus {
+    background-color: lighten($blue, 5%);
+
+    .expand-button-icon {
+      margin-right: 15px;
+    }
+  }
+
+  &.is-visible {
+    opacity: 1;
+    pointer-events: all;
+  }
+}
+
+.expand-button-icon {
+  margin-right: 10px;
+  transition: margin-right 0.2s ease;
 }

--- a/app/pods/components/header/template.hbs
+++ b/app/pods/components/header/template.hbs
@@ -1,4 +1,12 @@
 <div local-class="container">
+  <button
+    {{on "click" (fn this.collapse)}}
+    type="button"
+    local-class="header-button"
+  >
+    <FaIcon @icon="angle-right" />
+  </button>
+
   <LinkTo local-class="brand" @route="bookmarks">
     <img
       local-class="logo"
@@ -6,15 +14,24 @@
     >
 
     <div local-class="title">
-      {{! template-lint-disable no-bare-strings }}
-      Better Trading
-      {{! template-lint-enable no-bare-strings }}
+      {{t "general.title"}}
     </div>
   </LinkTo>
 
-  <nav local-class="navigation">
-    <LinkTo local-class="navigation-item" @route="about">
-      <FaIcon @icon="info-circle"/>
-    </LinkTo>
-  </nav>
+  <LinkTo local-class="header-button" @route="about">
+    <FaIcon @icon="info-circle"/>
+  </LinkTo>
 </div>
+
+<button
+  {{on "click" (fn this.expand)}}
+  type="button"
+  local-class="expand-button {{if this.expandButtonIsVisible "is-visible"}}"
+>
+  <FaIcon @icon="angle-left" local-class="expand-button-icon"/>
+
+  <img
+    local-class="logo"
+    src={{image-resource-url "logo.png"}}
+  >
+</button>

--- a/app/services/local-storage.ts
+++ b/app/services/local-storage.ts
@@ -8,6 +8,7 @@ const EXPIRY_SUFFIX = '--expires-at';
 const PAST_LEAGUES = ['Blight', 'Metamorph'];
 
 type LocalStorageKey =
+  | 'side-panel-collapsed'
   | 'bookmark-folders-expansion'
   | 'bookmark-folders'
   | 'bookmark-trades'

--- a/app/services/location.ts
+++ b/app/services/location.ts
@@ -30,7 +30,7 @@ export default class Location extends Service {
     return slug || null;
   }
 
-  getTradeURL(type: string, slug: string) {
+  getTradeUrl(type: string, slug: string) {
     const {league} = this.parseCurrentPath();
 
     return [BASE_URL, type, league, slug].join('/');

--- a/app/styles/_global.scss
+++ b/app/styles/_global.scss
@@ -16,7 +16,7 @@ body {
     overflow-y: auto;
     width: $extension-width;
     padding: 5px 10px;
-    background-color: $background;
+    background-color: rgba(#0a0a0a, 0.8);
     transition: right 0.2s ease;
   }
 

--- a/app/styles/_global.scss
+++ b/app/styles/_global.scss
@@ -1,20 +1,32 @@
 body {
   overflow-y: scroll;
-}
 
-#app {
-  width: calc(100% - #{$extension-width});
-  margin: 0;
-}
+  #app {
+    width: calc(100% - #{$extension-width});
+    margin: 0;
+    transition: width 0.2s ease;
+  }
 
-#better-trading-container {
-  position: fixed;
-  z-index: 1000;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  overflow-y: auto;
-  width: $extension-width;
-  padding: 5px 10px;
-  background-color: rgba(#0a0a0a, 0.8);
+  #better-trading-container {
+    position: fixed;
+    z-index: 1000;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    overflow-y: auto;
+    width: $extension-width;
+    padding: 5px 10px;
+    background-color: $background;
+    transition: right 0.2s ease;
+  }
+
+  &.bt-is-collapsed {
+    #app {
+      width: 100%;
+    }
+
+    #better-trading-container {
+      right: #{-1 * $extension-width};
+    }
+  }
 }

--- a/app/styles/overrides/_header.scss
+++ b/app/styles/overrides/_header.scss
@@ -1,3 +1,3 @@
-.logo a {
-  max-width: 155px !important;
+.bt-body .logo a {
+  max-width: 155px;
 }

--- a/app/styles/overrides/_search-panel.scss
+++ b/app/styles/overrides/_search-panel.scss
@@ -1,13 +1,15 @@
-@media (min-width: 1200px) and (max-width: #{1200px + $extension-width - 1px}) {
-  .col-lg-6,
-  #trade .search-bar .search-advanced-pane {
-    width: 100% !important;
+.bt-body:not(.bt-is-collapsed) {
+  @media (min-width: 1200px) and (max-width: #{1200px + $extension-width - 1px}) {
+    .col-lg-6,
+    #trade .search-bar .search-advanced-pane {
+      width: 100%;
+    }
   }
-}
 
-@media (min-width: #{#1200px + $extension-width}) {
-  .col-lg-6,
-  #trade .search-bar .search-advanced-pane {
-    width: 50%;
+  @media (min-width: #{#1200px + $extension-width}) {
+    .col-lg-6,
+    #trade .search-bar .search-advanced-pane {
+      width: 50%;
+    }
   }
 }

--- a/app/styles/overrides/_top-button.scss
+++ b/app/styles/overrides/_top-button.scss
@@ -1,3 +1,10 @@
-.top-btn {
-  right: #{$extension-width + 20px} !important;
+.bt-body {
+  .top-btn {
+    right: #{$extension-width + 20px};
+    transition: right 0.2s ease;
+  }
+
+  &.bt-is-collapsed .top-btn {
+    right: 20px;
+  }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -43,7 +43,9 @@ module.exports = function(environment) {
         'info-circle',
         'ellipsis-h',
         'sort',
-        'compress-alt'
+        'compress-alt',
+        'angle-right',
+        'angle-left'
       ],
       'free-brands-svg-icons': ['github', 'discord']
     }

--- a/tests/unit/services/location-test.ts
+++ b/tests/unit/services/location-test.ts
@@ -57,9 +57,11 @@ describe('Unit | Services | Location', () => {
     });
   });
 
-  describe('getTradeURL', () => {
+  describe('getTradeUrl', () => {
     it('should forge the proper URL', () => {
-      expect(service.getTradeURL('search', 'foobar')).to.be.equal(
+      window.location.pathname = '/trade/search/Legion/q1w2e3r4t5';
+
+      expect(service.getTradeUrl('search', 'foobar')).to.be.equal(
         'https://www.pathofexile.com/trade/search/Legion/foobar'
       );
     });

--- a/translations/general/en.yaml
+++ b/translations/general/en.yaml
@@ -1,0 +1,2 @@
+general:
+  title: Better Trading

--- a/translations/page/about/en.yaml
+++ b/translations/page/about/en.yaml
@@ -1,0 +1,17 @@
+page:
+  about:
+    disclaimer: This extension is fan-made and not affiliated with Grinding Gear Games in any way.
+    is-persisted: Data is safely persited in the browser.
+    discord:
+      title: On Discord
+      description: Stay tuned about upcoming updates and discuss future features.
+      button: Join the Discord server
+    github:
+      title: On GitHub
+      description: To contribute, report issues or simply browse the code.
+      button: View on GitHub
+    chaos-recipe-overlay:
+      title: Chaos Recipe Overlay
+      preview-alt: Overlay preview
+      description: Check out this simple overlay app that will track your chaos recipe bottlenecks.
+      button: View on GitHub

--- a/translations/page/bookmarks/en.yaml
+++ b/translations/page/bookmarks/en.yaml
@@ -36,19 +36,3 @@ page:
           label: Title
         icon:
           label: Icon
-  about:
-    disclaimer: This extension is fan-made and not affiliated with Grinding Gear Games in any way.
-    is-persisted: Data is safely persited in the browser.
-    discord:
-      title: On Discord
-      description: Stay tuned about upcoming updates and discuss future features.
-      button: Join the Discord server
-    github:
-      title: On GitHub
-      description: To contribute, report issues or simply browse the code.
-      button: View on GitHub
-    chaos-recipe-overlay:
-      title: Chaos Recipe Overlay
-      preview-alt: Overlay preview
-      description: Check out this simple overlay app that will track your chaos recipe bottlenecks.
-      button: View on GitHub


### PR DESCRIPTION
### ⚠️ Problem

A lot of people asked for the ability to close the side-panel, to save space.

### 👨‍💻 Solution

Introduce a collapse/expand button to collapse the side panel.

The layout overrides that were made to the trading site are only active if the panel is there.

### 👀 Preview

![Kapture 2020-03-27 at 19 03 46](https://user-images.githubusercontent.com/4255460/77807713-08333880-705f-11ea-8da9-1cfd0e620517.gif)

### 🤖 Beep beep bop

resolves: #21