### PR TITLE
Feature/exalts equivalent

### DIFF
--- a/app/services/item-results/equivalent-pricings.ts
+++ b/app/services/item-results/equivalent-pricings.ts
@@ -29,7 +29,7 @@ export default class ItemResultsEquivalentPricings extends Service {
   @service('location')
   location: Location;
 
-  private chaosRatios: PoeNinjaCurrenciesRatios | null;
+  chaosRatios: PoeNinjaCurrenciesRatios | null;
 
   async prepare(): Promise<void> {
     this.chaosRatios = await this.poeNinja.fetchChaosRatiosFor(this.location.league);

--- a/app/services/item-results/equivalent-pricings.ts
+++ b/app/services/item-results/equivalent-pricings.ts
@@ -11,6 +11,11 @@ import PoeNinja, {PoeNinjaCurrenciesRatios} from 'better-trading/services/poe-ni
 // Constants
 const CHAOS_IMAGE_URL = 'https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyRerollRare.png';
 const CHAOS_ALT = 'chaos';
+const CHAOS_SLUG = 'chaos-orb';
+const EXALT_IMAGE_URL = 'https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyAddModToRare.png';
+const EXALT_ALT = 'exalt';
+const EXALT_SLUG = 'exalted-orb';
+const EXALT_EQUIVALENCE_THRESHOLD = 0.5;
 const PRICING_CONTAINER_SELECTOR = '.price';
 const CURRENCY_NAME_SELECTOR = '[data-field="price"] .currency-text span';
 const CURRENCY_IMAGE_SELECTOR = '[data-field="price"] .currency-image img';
@@ -34,9 +39,9 @@ export default class ItemResultsEquivalentPricings extends Service {
   process(result: HTMLElement): void {
     if (!this.chaosRatios) return;
 
-    const pricingContainerElement = result.querySelector(PRICING_CONTAINER_SELECTOR);
-    const currencyNameElement = result.querySelector(CURRENCY_NAME_SELECTOR);
-    const currencyValueElement = result.querySelector(CURRENCY_VALUE_SELECTOR);
+    const pricingContainerElement = result.querySelector(PRICING_CONTAINER_SELECTOR) as HTMLElement;
+    const currencyNameElement = result.querySelector(CURRENCY_NAME_SELECTOR) as HTMLElement;
+    const currencyValueElement = result.querySelector(CURRENCY_VALUE_SELECTOR) as HTMLElement;
     const currencyImageElement = result.querySelector(CURRENCY_IMAGE_SELECTOR) as HTMLImageElement;
 
     if (!currencyNameElement) return;
@@ -47,8 +52,21 @@ export default class ItemResultsEquivalentPricings extends Service {
     const currencySlug = slugify(currencyNameElement.textContent || '');
     const currencyValue = parseFloat(currencyValueElement.textContent || '');
     const chaosValue = this.chaosRatios[currencySlug];
-    if (!chaosValue || !currencyValue) return;
+    const exaltValue = this.chaosRatios[EXALT_SLUG];
 
+    if (chaosValue && currencyValue) {
+      this.handleNonChaosPricedItem(pricingContainerElement, currencyImageElement, currencyValue, chaosValue);
+    } else if (currencySlug === CHAOS_SLUG && exaltValue) {
+      this.handleChaosPricedItem(pricingContainerElement, currencyValue, exaltValue);
+    }
+  }
+
+  private handleNonChaosPricedItem(
+    pricingContainerElement: HTMLElement,
+    currencyImageElement: HTMLImageElement,
+    currencyValue: number,
+    chaosValue: number
+  ) {
     const chaosEquivalentValue = Math.round(currencyValue * chaosValue);
     if (!chaosEquivalentValue) return;
 
@@ -66,6 +84,14 @@ export default class ItemResultsEquivalentPricings extends Service {
         chaosFractionValue
       )
     );
+  }
+
+  private handleChaosPricedItem(pricingContainerElement: HTMLElement, currencyValue: number, exaltValue: number) {
+    if (currencyValue < EXALT_EQUIVALENCE_THRESHOLD * exaltValue) return;
+
+    // eslint-disable-next-line no-magic-numbers
+    const exaltEquivalentValue = Math.round((currencyValue / exaltValue) * 10) / 10;
+    pricingContainerElement.append(this.renderExaltEquivalence(exaltEquivalentValue));
   }
 
   private renderChaosEquivalence(chaosEquivalentValue: number): HTMLElement {
@@ -91,6 +117,16 @@ export default class ItemResultsEquivalentPricings extends Service {
     const flooredPart = `${flooredCurrencyValue}×<img src="${currencyIconUrl}" alt="${currencyIconAlt}" />`;
     const fractionPart = `+${chaosFractionValue}×<img src="${CHAOS_IMAGE_URL}" alt="${CHAOS_ALT}" />`;
     element.innerHTML = `<span>${EQUAL_HTML}${flooredPart}${fractionPart}</span>`;
+
+    return element;
+  }
+
+  private renderExaltEquivalence(exaltEquivalentValue: number): HTMLElement {
+    const element = window.document.createElement('span');
+    element.classList.add('bt-equivalent-pricings');
+    element.classList.add('bt-equivalent-pricings-equivalent');
+
+    element.innerHTML = `<span>${EQUAL_HTML}${exaltEquivalentValue}×<img src="${EXALT_IMAGE_URL}" alt="${EXALT_ALT}" /></span>`;
 
     return element;
   }

--- a/app/services/item-results/equivalent-pricings.ts
+++ b/app/services/item-results/equivalent-pricings.ts
@@ -44,10 +44,7 @@ export default class ItemResultsEquivalentPricings extends Service {
     const currencyValueElement = result.querySelector(CURRENCY_VALUE_SELECTOR) as HTMLElement;
     const currencyImageElement = result.querySelector(CURRENCY_IMAGE_SELECTOR) as HTMLImageElement;
 
-    if (!currencyNameElement) return;
-    if (!pricingContainerElement) return;
-    if (!currencyValueElement) return;
-    if (!currencyImageElement) return;
+    if (!pricingContainerElement || !currencyNameElement || !currencyValueElement || !currencyImageElement) return;
 
     const currencySlug = slugify(currencyNameElement.textContent || '');
     const currencyValue = parseFloat(currencyValueElement.textContent || '');

--- a/tests/html-samples/item-results/flush-exalt.ts
+++ b/tests/html-samples/item-results/flush-exalt.ts
@@ -1,0 +1,86 @@
+export default `
+<div data-id="4fcd1714d23febd2a33831d89ce7f7a20b0e64755a9186e7f1925009c7f7b796" class="row">
+  <div class="left">
+    <button title="Refresh" class="refresh"></button>
+    <button title="Copy Item" class="copy"></button>
+    <button title="Filter by Item Stats" class="searchBy"></button>
+    <div class="newItemContainer itemRendered iW1 iH1">
+      <div class="iconContainer">
+        <div class="icon"><img
+          src="https://web.poecdn.com/image/Art/2DItems/Rings/TheTaming.png?w=1&amp;h=1&amp;scale=1&amp;v=f242137d35b413169ce463d38abcbe48"
+          alt="">
+          <div class="sockets numSockets0"></div> <!----></div>
+        <div class="verifiedStatus">Verified</div>
+      </div>
+    </div>
+  </div>
+  <div class="middle">
+    <div class="itemPopupContainer newItemPopup uniquePopup">
+      <div class="itemBoxContent">
+        <div class="itemHeader doubleLine">
+          <span class="l "></span>
+          <div class="itemName">
+            <span class="lc">The Taming</span>
+          </div>
+          <div class="itemName typeLine">
+            <span class="lc">Prismatic Ring</span>
+          </div>
+          <span class="r "></span>
+        </div>
+        <div class="content">
+          <div class="displayProperty"><span class="lc s" data-field="quality"><span>Quality (Elemental Damage)</span>: <span
+            class="colourAugmented">+20%</span></span></div>
+          <div class="separator"></div>
+          <div class="displayProperty"><span class="lc s" data-field="ilvl">Item Level: <span
+            class="colourDefault">84</span></span></div>
+          <div class="requirements"><span class="lc">
+            Requires <span>Level</span> <span class="colourDefault">30</span>
+            </span></div>
+          <div class="separator"></div>
+          <div class="implicitMod" data-mod="0"><span class="lc l"><span class="d">[8—10]</span></span><span
+            class="lc s" data-field="stat.implicit.stat_2901986750">+10% to all Elemental Resistances</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="separator"></div>
+          <div class="explicitMod" data-mod="1"><span class="lc l"><span class="d">[20]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_4229711086">24% increased Damage with Hits and Ailments per Freeze, Shock or Ignite on Enemy</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="2"><span class="lc l"><span class="d">[20—30]</span></span><span
+            class="lc s" data-field="stat.explicit.stat_2901986750">+30% to all Elemental Resistances</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="3"><span class="lc l"><span class="d">[30]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_3141070085">36% increased Elemental Damage</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="0"><span class="lc l"><span class="d">[10]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_800141891">12% chance to Freeze, Shock and Ignite</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="4"><span class="lc l"><span class="d">[30]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_387439868">36% increased Elemental Damage with Attack Skills</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="separator"></div>
+          <div class="textCurrency itemNote">~b/o 1 exa</div>
+        </div>
+      </div>
+    </div> <!----> <!----></div>
+  <div class="right">
+    <div class="details">
+      <div class="price"><span data-field="price" class="s sorted sorted-asc"><span class="price-label buyout-price">Exact Price:</span><br> <span>1</span><span>×</span><span
+        class="currency-text currency-image"><img
+        src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyAddModToRare.png?v=1745ebafbd533b6f91bccf588ab5efc5"
+        alt="exa" title="exa"><span>Exalted Orb</span></span></span></div>
+      <div data-field="indexed" class="info s"><span class="profile-link"><a href="/account/view-profile/foobar"
+                                                                             target="_blank">foobar</a></span>&nbsp;<small>
+        listed an hour ago
+      </small>
+      </div> <!---->
+      <div role="group" aria-label="Contact Options" class="btns"><span class="pull-left"><span title="Delirium"
+                                                                                                class="status status-online">Online</span><span
+        class="character-name">IGN: foobar</span><button
+        class="btn btn-default whisper-btn">Whisper</button><a role="button" href="/private-messages/compose?to=foobar"
+                                                               target="_blank"
+                                                               class="btn btn-default pm-btn">PM</a></span> <!---->
+        <div class="clear"></div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/html-samples/item-results/fraction-exalt.ts
+++ b/tests/html-samples/item-results/fraction-exalt.ts
@@ -1,0 +1,86 @@
+export default `
+<div data-id="3ff75b24c5e925b828f08da170ea0fa3d9988306c06a665886d4e9bbb37a9ef4" class="row">
+  <div class="left">
+    <button title="Refresh" class="refresh"></button>
+    <button title="Copy Item" class="copy"></button>
+    <button title="Filter by Item Stats" class="searchBy"></button>
+    <div class="newItemContainer itemRendered iW1 iH1">
+      <div class="iconContainer">
+        <div class="icon"><img
+          src="https://web.poecdn.com/image/Art/2DItems/Rings/TheTaming.png?w=1&amp;h=1&amp;scale=1&amp;v=f242137d35b413169ce463d38abcbe48"
+          alt="">
+          <div class="sockets numSockets0"></div> <!----></div>
+        <div class="verifiedStatus">Verified</div>
+      </div>
+    </div>
+  </div>
+  <div class="middle">
+    <div class="itemPopupContainer newItemPopup uniquePopup">
+      <div class="itemBoxContent">
+        <div class="itemHeader doubleLine">
+          <span class="l "></span>
+          <div class="itemName">
+            <span class="lc">The Taming</span>
+          </div>
+          <div class="itemName typeLine">
+            <span class="lc">Prismatic Ring</span>
+          </div>
+          <span class="r "></span>
+        </div>
+        <div class="content">
+          <div class="displayProperty"><span class="lc s"
+                                             data-field="quality"><span>Quality (Resistance Modifiers)</span>: <span
+            class="colourAugmented">+20%</span></span></div>
+          <div class="separator"></div>
+          <div class="displayProperty"><span class="lc s" data-field="ilvl">Item Level: <span
+            class="colourDefault">74</span></span></div>
+          <div class="requirements"><span class="lc">
+            Requires <span>Level</span> <span class="colourDefault">30</span>
+            </span></div>
+          <div class="separator"></div>
+          <div class="implicitMod" data-mod="0"><span class="lc l"><span class="d">[8—10]</span></span><span
+            class="lc s" data-field="stat.implicit.stat_2901986750">+12% to all Elemental Resistances</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="separator"></div>
+          <div class="explicitMod" data-mod="1"><span class="lc l"><span class="d">[20]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_4229711086">20% increased Damage with Hits and Ailments per Freeze, Shock or Ignite on Enemy</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="2"><span class="lc l"><span class="d">[20—30]</span></span><span
+            class="lc s" data-field="stat.explicit.stat_2901986750">+33% to all Elemental Resistances</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="3"><span class="lc l"><span class="d">[30]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_3141070085">30% increased Elemental Damage</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="0"><span class="lc l"><span class="d">[10]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_800141891">10% chance to Freeze, Shock and Ignite</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="4"><span class="lc l"><span class="d">[30]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_387439868">30% increased Elemental Damage with Attack Skills</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="separator"></div>
+          <div class="textCurrency itemNote">~price 1.1 exa</div>
+        </div>
+      </div>
+    </div> <!----> <!----></div>
+  <div class="right">
+    <div class="details">
+      <div class="price"><span data-field="price" class="s sorted sorted-asc"><span class="price-label fixed-price">Exact Price:</span><br> <span>1.1</span><span>×</span><span
+        class="currency-text currency-image"><img
+        src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyAddModToRare.png?v=1745ebafbd533b6f91bccf588ab5efc5"
+        alt="exa" title="exa"><span>Exalted Orb</span></span></span></div>
+      <div data-field="indexed" class="info s"><span class="profile-link"><a href="/account/view-profile/foobar"
+                                                                             target="_blank">foobar</a></span>&nbsp;<small>
+        listed 3 days ago
+      </small>
+      </div> <!---->
+      <div role="group" aria-label="Contact Options" class="btns"><span class="pull-left"><span title="Delirium"
+                                                                                                class="status status-online">Online</span><span
+        class="character-name">IGN: foobar</span><button class="btn btn-default whisper-btn">Whisper</button><a
+        role="button" href="/private-messages/compose?to=foobar" target="_blank" class="btn btn-default pm-btn">PM</a></span>
+        <!---->
+        <div class="clear"></div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/html-samples/item-results/hundred-chaos.ts
+++ b/tests/html-samples/item-results/hundred-chaos.ts
@@ -1,0 +1,94 @@
+export default `
+<div data-id="b42e9afdbdcd52a8063785262af4d2e9f904449703bc3f15e00677f6eaf50a7d" class="row">
+  <div class="left">
+    <button title="Refresh" class="refresh"></button>
+    <button title="Copy Item" class="copy"></button>
+    <button title="Filter by Item Stats" class="searchBy"></button>
+    <div class="newItemContainer itemRendered iW1 iH1">
+      <div class="iconContainer">
+        <div class="icon"><img
+          src="https://web.poecdn.com/image/Art/2DItems/Rings/TheTaming.png?w=1&amp;h=1&amp;scale=1&amp;v=f242137d35b413169ce463d38abcbe48"
+          alt="">
+          <div class="sockets numSockets0"></div> <!----></div>
+        <div class="verifiedStatus">Verified</div>
+      </div>
+    </div>
+  </div>
+  <div class="middle">
+    <div class="itemPopupContainer newItemPopup uniquePopup">
+      <div class="itemBoxContent">
+        <div class="itemHeader doubleLine">
+          <span class="l "></span>
+          <div class="itemName">
+            <span class="lc">The Taming</span>
+          </div>
+          <div class="itemName typeLine">
+            <span class="lc">Prismatic Ring</span>
+          </div>
+          <span class="r "></span>
+        </div>
+        <div class="content">
+          <div class="displayProperty"><span class="lc s"
+                                             data-field="quality"><span>Quality (Resistance Modifiers)</span>: <span
+            class="colourAugmented">+20%</span></span></div>
+          <div class="separator"></div>
+          <div class="displayProperty"><span class="lc s" data-field="ilvl">Item Level: <span
+            class="colourDefault">80</span></span></div>
+          <div class="requirements"><span class="lc">
+            Requires <span>Level</span> <span class="colourDefault">30</span>
+            </span></div>
+          <div class="separator"></div>
+          <div class="implicitMod" data-mod="0"><span class="lc l"><span class="d">[8—10]</span></span><span
+            class="lc s" data-field="stat.implicit.stat_2901986750">+12% to all Elemental Resistances</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="separator"></div>
+          <div class="explicitMod" data-mod="1"><span class="lc l"><span class="d">[20]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_4229711086">20% increased Damage with Hits and Ailments per Freeze, Shock or Ignite on Enemy</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="2"><span class="lc l"><span class="d">[20—30]</span></span><span
+            class="lc s" data-field="stat.explicit.stat_2901986750">+32% to all Elemental Resistances</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="3"><span class="lc l"><span class="d">[30]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_3141070085">30% increased Elemental Damage</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="0"><span class="lc l"><span class="d">[10]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_800141891">10% chance to Freeze, Shock and Ignite</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="explicitMod" data-mod="4"><span class="lc l"><span class="d">[30]</span></span><span class="lc s"
+                                                                                                           data-field="stat.explicit.stat_387439868">30% increased Elemental Damage with Attack Skills</span><span
+            class="lc r"><span class="d"></span></span></div>
+          <div class="separator"></div>
+          <div class="incubated">
+            <div class="text"><span>Incubating 6-Linked Armour Item</span></div>
+            <span class="experienceBar"><span class="fill"><span style="width: 10%;"></span></span></span>
+            <div class="descrText"><span><span class="progress">2,969/28,998</span> Level 68+ Monster Kills</span></div>
+          </div>
+          <div class="separator"></div>
+          <div class="textCurrency itemNote">~price 100 chaos</div>
+        </div>
+      </div>
+    </div> <!----> <!----></div>
+  <div class="right">
+    <div class="details">
+      <div class="price"><span data-field="price" class="s sorted sorted-asc"><span class="price-label fixed-price">Exact Price:</span><br> <span>100</span><span>×</span><span
+        class="currency-text currency-image"><img
+        src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyRerollRare.png?v=c60aa876dd6bab31174df91b1da1b4f9"
+        alt="chaos" title="chaos"><span>Chaos Orb</span></span></span></div>
+      <div data-field="indexed" class="info s"><span class="profile-link"><a href="/account/view-profile/foobar"
+                                                                             target="_blank">foobar</a></span>&nbsp;<small>
+        listed 2 hours ago
+      </small>
+      </div> <!---->
+      <div role="group" aria-label="Contact Options" class="btns"><span class="pull-left"><span title="Delirium"
+                                                                                                class="status status-away">AFK</span><span
+        class="character-name">IGN: foobar</span><button
+        class="btn btn-default whisper-btn">Whisper</button><a role="button"
+                                                               href="/private-messages/compose?to=foobar"
+                                                               target="_blank"
+                                                               class="btn btn-default pm-btn">PM</a></span> <!---->
+        <div class="clear"></div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/unit/services/item-results/equivalent-pricings-test.ts
+++ b/tests/unit/services/item-results/equivalent-pricings-test.ts
@@ -1,0 +1,71 @@
+// Vendor
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+import {default as window} from 'ember-window-mock';
+import {beforeEach, afterEach, describe, it} from 'mocha';
+
+// HTML Samples
+import HundredChaosElement from 'better-trading/tests/html-samples/item-results/hundred-chaos';
+import FlushExaltElement from 'better-trading/tests/html-samples/item-results/flush-exalt';
+import FractionExaltElement from 'better-trading/tests/html-samples/item-results/fraction-exalt';
+
+// Types
+import ItemResultsEquivalentPricings from 'better-trading/services/item-results/equivalent-pricings';
+
+describe('Unit | Services | ItemResults | EquivalentPricings', () => {
+  setupTest();
+
+  let service: ItemResultsEquivalentPricings;
+  let resultsContainer: HTMLDivElement;
+
+  beforeEach(function() {
+    service = this.owner.lookup('service:item-results/equivalent-pricings');
+
+    service.chaosRatios = {
+      'exalted-orb': 150
+    };
+
+    resultsContainer = window.document.createElement('div');
+    resultsContainer.style.display = 'none';
+    window.document.body.prepend(resultsContainer);
+  });
+
+  afterEach(() => {
+    resultsContainer.remove();
+  });
+
+  describe('process', () => {
+    it('should display the exalt equivalence for valuable chaos items', () => {
+      resultsContainer.insertAdjacentHTML('afterbegin', HundredChaosElement);
+      service.process(resultsContainer.querySelector('div') as HTMLDivElement);
+
+      const priceElement = resultsContainer.querySelector('.details .price') as HTMLDivElement;
+      expect(priceElement.innerText.trim()).to.equal('Exact Price: 100×Chaos Orb=0.7×');
+      expect(priceElement.innerHTML.trim()).to.equal(
+        '<span data-field="price" class="s sorted sorted-asc"><span class="price-label fixed-price">Exact Price:</span><br> <span>100</span><span>×</span><span class="currency-text currency-image"><img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyRerollRare.png?v=c60aa876dd6bab31174df91b1da1b4f9" alt="chaos" title="chaos"><span>Chaos Orb</span></span></span><span class="bt-equivalent-pricings bt-equivalent-pricings-equivalent"><span><span class="bt-equivalent-pricings-equals">=</span>0.7×<img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyAddModToRare.png" alt="exalt"></span></span>'
+      );
+    });
+
+    it('should display the chaos equivalence for non-chaos items', () => {
+      resultsContainer.insertAdjacentHTML('afterbegin', FlushExaltElement);
+      service.process(resultsContainer.querySelector('div') as HTMLDivElement);
+
+      const priceElement = resultsContainer.querySelector('.details .price') as HTMLDivElement;
+      expect(priceElement.innerText.trim()).to.equal('Exact Price: 1×Exalted Orb=150×');
+      expect(priceElement.innerHTML.trim()).to.equal(
+        '<span data-field="price" class="s sorted sorted-asc"><span class="price-label buyout-price">Exact Price:</span><br> <span>1</span><span>×</span><span class="currency-text currency-image"><img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyAddModToRare.png?v=1745ebafbd533b6f91bccf588ab5efc5" alt="exa" title="exa"><span>Exalted Orb</span></span></span><span class="bt-equivalent-pricings bt-equivalent-pricings-equivalent"><span><span class="bt-equivalent-pricings-equals">=</span>150×<img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyRerollRare.png" alt="chaos"></span></span>'
+      );
+    });
+
+    it('should also display the non-chaos fraction if the result is not flush', () => {
+      resultsContainer.insertAdjacentHTML('afterbegin', FractionExaltElement);
+      service.process(resultsContainer.querySelector('div') as HTMLDivElement);
+
+      const priceElement = resultsContainer.querySelector('.details .price') as HTMLDivElement;
+      expect(priceElement.innerText.trim()).to.equal('Exact Price: 1.1×Exalted Orb=165×=1×+15×');
+      expect(priceElement.innerHTML.trim()).to.equal(
+        '<span data-field="price" class="s sorted sorted-asc"><span class="price-label fixed-price">Exact Price:</span><br> <span>1.1</span><span>×</span><span class="currency-text currency-image"><img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyAddModToRare.png?v=1745ebafbd533b6f91bccf588ab5efc5" alt="exa" title="exa"><span>Exalted Orb</span></span></span><span class="bt-equivalent-pricings bt-equivalent-pricings-equivalent"><span><span class="bt-equivalent-pricings-equals">=</span>165×<img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyRerollRare.png" alt="chaos"></span></span><span class="bt-equivalent-pricings bt-equivalent-pricings-chaos-fraction"><span><span class="bt-equivalent-pricings-equals">=</span>1×<img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyAddModToRare.png?v=1745ebafbd533b6f91bccf588ab5efc5" alt="exa">+15×<img src="https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyRerollRare.png" alt="chaos"></span></span>'
+      );
+    });
+  });
+});

--- a/tests/unit/services/search-panel-test.ts
+++ b/tests/unit/services/search-panel-test.ts
@@ -4,9 +4,9 @@ import {setupTest} from 'ember-mocha';
 import {beforeEach, afterEach, describe, it} from 'mocha';
 
 // HTML Samples
-import AnonItem from '../../html-samples/search-panel/anon-ele-res-max-life';
-import UniqueItem from '../../html-samples/search-panel/belly-of-the-beast-6l-no-corrupt';
-import RareJewel from '../../html-samples/search-panel/rare-jewel';
+import AnonItem from 'better-trading/tests/html-samples/search-panel/anon-ele-res-max-life';
+import UniqueItem from 'better-trading/tests/html-samples/search-panel/belly-of-the-beast-6l-no-corrupt';
+import RareJewel from 'better-trading/tests/html-samples/search-panel/rare-jewel';
 
 // Types
 import SearchPanel from 'better-trading/services/search-panel';


### PR DESCRIPTION
### 👨‍💻 Feature

For items with a large chaos price (at least 0.5 ex), display the exalt equivalent price. It will be easier to compare prices for items that are close to the 1ex value.

### 👀 Preview

![image](https://user-images.githubusercontent.com/4255460/80892294-e0a34180-8c96-11ea-968b-2a857955bede.png)

### 🤖 Beep beep bop

resolves: #31 