### PR TITLE
Introduce the maximum sockets item result enhancer

### DIFF
--- a/app/services/item-results.ts
+++ b/app/services/item-results.ts
@@ -3,7 +3,7 @@ import Service, {inject as service} from '@ember/service';
 import Evented from '@ember/object/evented';
 
 // Types
-import ItemResultsEnhancersPinnable from 'better-trading/services/item-results/enhancers/pinnable';
+import Pinnable from 'better-trading/services/item-results/enhancers/pinnable';
 
 // Utilities
 import ItemResultsEnhance from 'better-trading/services/item-results/enhance';
@@ -13,7 +13,7 @@ export default class ItemResults extends Service.extend(Evented) {
   itemResultsEnhance: ItemResultsEnhance;
 
   @service('item-results/enhancers/pinnable')
-  itemResultsEnhancersPinnable: ItemResultsEnhancersPinnable;
+  itemResultsEnhancersPinnable: Pinnable;
 
   async initialize() {
     await this.itemResultsEnhance.initialize();

--- a/app/services/item-results/enhance.ts
+++ b/app/services/item-results/enhance.ts
@@ -5,9 +5,10 @@ import window from 'ember-window-mock';
 
 // Types
 import {ItemResultsEnhancerService} from 'better-trading/types/item-results';
-import ItemResultsEnhancersHighlightStatFilters from 'better-trading/services/item-results/enhancers/highlight-stat-filters';
-import ItemResultsEnhancersEquivalentPricings from 'better-trading/services/item-results/enhancers/equivalent-pricings';
-import ItemResultsEnhancersPinnable from 'better-trading/services/item-results/enhancers/pinnable';
+import HighlightStatFilters from 'better-trading/services/item-results/enhancers/highlight-stat-filters';
+import EquivalentPricings from 'better-trading/services/item-results/enhancers/equivalent-pricings';
+import Pinnable from 'better-trading/services/item-results/enhancers/pinnable';
+import MaximumSockets from 'better-trading/services/item-results/enhancers/maximum-sockets';
 import {Task} from 'better-trading/types/ember-concurrency';
 
 // Utilities
@@ -15,13 +16,16 @@ import {asyncLoop} from 'better-trading/utilities/async-loop';
 
 export default class ItemResultsEnhance extends Service {
   @service('item-results/enhancers/highlight-stat-filters')
-  itemResultsEnhancersHighlightStatFilters: ItemResultsEnhancersHighlightStatFilters;
+  itemResultsEnhancersHighlightStatFilters: HighlightStatFilters;
 
   @service('item-results/enhancers/equivalent-pricings')
-  itemResultsEnhancersEquivalentPricings: ItemResultsEnhancersEquivalentPricings;
+  itemResultsEnhancersEquivalentPricings: EquivalentPricings;
 
   @service('item-results/enhancers/pinnable')
-  itemResultsEnhancersPinnable: ItemResultsEnhancersPinnable;
+  itemResultsEnhancersPinnable: Pinnable;
+
+  @service('item-results/enhancers/maximum-sockets')
+  itemResultsEnhancersMaximumSockets: MaximumSockets;
 
   resultsObserver: MutationObserver;
 
@@ -29,7 +33,8 @@ export default class ItemResultsEnhance extends Service {
     return [
       this.itemResultsEnhancersHighlightStatFilters,
       this.itemResultsEnhancersEquivalentPricings,
-      this.itemResultsEnhancersPinnable
+      this.itemResultsEnhancersPinnable,
+      this.itemResultsEnhancersMaximumSockets
     ];
   }
 

--- a/app/services/item-results/enhancers/equivalent-pricings.ts
+++ b/app/services/item-results/enhancers/equivalent-pricings.ts
@@ -23,7 +23,7 @@ const CURRENCY_IMAGE_SELECTOR = '[data-field="price"] .currency-image img';
 const CURRENCY_VALUE_SELECTOR = '[data-field="price"] > br + span';
 const EQUAL_HTML = '<span class="bt-equivalent-pricings-equals">=</span>';
 
-export default class ItemResultsEnhancersEquivalentPricings extends Service implements ItemResultsEnhancerService {
+export default class EquivalentPricings extends Service implements ItemResultsEnhancerService {
   @service('poe-ninja')
   poeNinja: PoeNinja;
 
@@ -133,6 +133,6 @@ export default class ItemResultsEnhancersEquivalentPricings extends Service impl
 
 declare module '@ember/service' {
   interface Registry {
-    'item-results/enhancers/equivalent-pricings': ItemResultsEnhancersEquivalentPricings;
+    'item-results/enhancers/equivalent-pricings': EquivalentPricings;
   }
 }

--- a/app/services/item-results/enhancers/highlight-stat-filters.ts
+++ b/app/services/item-results/enhancers/highlight-stat-filters.ts
@@ -11,7 +11,7 @@ import {ItemResultsEnhancerService} from 'better-trading/types/item-results';
 // Constants
 const MODS_SELECTOR = '.explicitMod,.pseudoMod,.implicitMod';
 
-export default class ItemResultsEnhancersHighlightStatFilters extends Service implements ItemResultsEnhancerService {
+export default class HighlightStatFilters extends Service implements ItemResultsEnhancerService {
   @service('search-panel')
   searchPanel: SearchPanel;
 
@@ -37,6 +37,6 @@ export default class ItemResultsEnhancersHighlightStatFilters extends Service im
 
 declare module '@ember/service' {
   interface Registry {
-    'item-results/enhancers/highlight-stat-filters': ItemResultsEnhancersHighlightStatFilters;
+    'item-results/enhancers/highlight-stat-filters': HighlightStatFilters;
   }
 }

--- a/app/services/item-results/enhancers/maximum-sockets.ts
+++ b/app/services/item-results/enhancers/maximum-sockets.ts
@@ -20,6 +20,9 @@ export default class MaximumSockets extends Service implements ItemResultsEnhanc
   statNeedles: RegExp[];
 
   enhance(result: HTMLElement) {
+    // Check for non-socketable items
+    if (result.querySelector('.numSockets0')) return;
+
     const ilvlElement = result.querySelector('.itemLevel');
 
     const ilvlMatch = ilvlElement?.textContent?.match(/(\d+)/);

--- a/app/services/item-results/enhancers/maximum-sockets.ts
+++ b/app/services/item-results/enhancers/maximum-sockets.ts
@@ -1,0 +1,51 @@
+// Vendor
+import Service, {inject as service} from '@ember/service';
+
+// Types
+import {ItemResultsEnhancerService} from 'better-trading/types/item-results';
+import IntlService from 'ember-intl/services/intl';
+
+// Constants
+const ILVL_THRESHOLDS = [
+  {maxSockets: 2, ilvl: 1},
+  {maxSockets: 3, ilvl: 24},
+  {maxSockets: 4, ilvl: 34},
+  {maxSockets: 5, ilvl: 49}
+];
+
+export default class MaximumSockets extends Service implements ItemResultsEnhancerService {
+  @service('intl')
+  intl: IntlService;
+
+  statNeedles: RegExp[];
+
+  enhance(result: HTMLElement) {
+    const ilvlElement = result.querySelector('.itemLevel');
+
+    const ilvlMatch = ilvlElement?.textContent?.match(/(\d+)/);
+    if (!ilvlMatch) return;
+
+    const ilvl = parseInt(ilvlMatch[0], 10);
+    const applicableThreshold = ILVL_THRESHOLDS.find(threshold => ilvl <= threshold.ilvl);
+    if (!applicableThreshold) return;
+
+    const iconElement = result.querySelector('.itemRendered');
+    if (!iconElement) return;
+
+    iconElement.prepend(this.renderWarning(applicableThreshold.maxSockets));
+  }
+
+  private renderWarning(maximumSockets: number) {
+    const warningElement = window.document.createElement('div');
+    warningElement.textContent = this.intl.t('item-results.maximum-sockets.warning', {maximum: maximumSockets});
+    warningElement.classList.add('bt-maximum-sockets');
+
+    return warningElement;
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'item-results/enhancers/maximum-sockets': MaximumSockets;
+  }
+}

--- a/app/services/item-results/enhancers/pinnable.ts
+++ b/app/services/item-results/enhancers/pinnable.ts
@@ -11,7 +11,7 @@ interface PinnedItemsMap {
   [id: string]: ItemResultsPinnedItem;
 }
 
-export default class ItemResultsEnhancersPinnable extends Service implements ItemResultsEnhancerService {
+export default class Pinnable extends Service implements ItemResultsEnhancerService {
   @service('item-results')
   itemResults: ItemResults;
 
@@ -119,6 +119,6 @@ export default class ItemResultsEnhancersPinnable extends Service implements Ite
 
 declare module '@ember/service' {
   interface Registry {
-    'item-results/enhancers/pinnable': ItemResultsEnhancersPinnable;
+    'item-results/enhancers/pinnable': Pinnable;
   }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -14,6 +14,7 @@
 @import 'globals/equivalent-pricings';
 @import 'globals/header';
 @import 'globals/highlight-stat-filters';
+@import 'globals/maximum-sockets';
 @import 'globals/pinnable';
 @import 'globals/search-panel';
 @import 'globals/top-button';

--- a/app/styles/globals/_maximum-sockets.scss
+++ b/app/styles/globals/_maximum-sockets.scss
@@ -1,0 +1,10 @@
+.bt-maximum-sockets {
+  min-height: 15px;
+  padding: 1px 4px;
+  border: 1px solid #333;
+  background-color: #000;
+  text-align: center;
+  font-size: 85%;
+  font-weight: bold;
+  color: #aaa;
+}

--- a/tests/unit/services/item-results/enhancers/equivalent-pricings-test.ts
+++ b/tests/unit/services/item-results/enhancers/equivalent-pricings-test.ts
@@ -10,12 +10,12 @@ import FlushExaltElement from 'better-trading/tests/html-samples/item-results/fl
 import FractionExaltElement from 'better-trading/tests/html-samples/item-results/fraction-exalt';
 
 // Types
-import ItemResultsEnhancersEquivalentPricings from 'better-trading/services/item-results/enhancers/equivalent-pricings';
+import EquivalentPricings from 'better-trading/services/item-results/enhancers/equivalent-pricings';
 
 describe('Unit | Services | ItemResults | Enhancers | EquivalentPricings', () => {
   setupTest();
 
-  let service: ItemResultsEnhancersEquivalentPricings;
+  let service: EquivalentPricings;
   let resultsContainer: HTMLDivElement;
 
   beforeEach(function() {

--- a/translations/item-results/en.yaml
+++ b/translations/item-results/en.yaml
@@ -2,3 +2,5 @@ item-results:
   pinnable:
     pin: Pin
     unpin: Unpin
+  maximum-sockets:
+    warning: 'Max. {maximum} sockets'


### PR DESCRIPTION
### 👨‍💻 Feature

Sometime, your snipe a good deal on an item just to find out it cannot reach 6 sockets. It's because the maximum number of sockets is determined by the item's ilvl.

This feature will display a little info-box for socketable items that are limited (ie cannot reach 6 sockets)

### 👀 Preview

![image](https://user-images.githubusercontent.com/4255460/91667943-61077100-ead6-11ea-8e5b-c63f307a43fc.png)

### 🤖 Beep beep bop

github: #50 