### PR TITLE
Prevent the bookmark Live menu item to show-up for bulk trade

### DIFF
--- a/app/pods/components/page/bookmarks/folder/template.hbs
+++ b/app/pods/components/page/bookmarks/folder/template.hbs
@@ -88,10 +88,12 @@
                   @label={{t "page.bookmarks.folder.copy-trade-to-clipboard"}}
                   @onClick={{fn this.copyToClipboard trade}}
                 />
-                <MenuItem
-                  @href={{trade-url trade.location league=this.currentLeague suffix="/live"}}
-                  @label={{t "page.bookmarks.folder.open-live-trade"}}
-                />
+                {{#if (eq trade.location.type "search")}}
+                  <MenuItem
+                    @href={{trade-url trade.location league=this.currentLeague suffix="/live"}}
+                    @label={{t "page.bookmarks.folder.open-live-trade"}}
+                  />
+                {{/if}}
                 <MenuItem
                   @label={{t "page.bookmarks.folder.update-trade-location"}}
                   @onClick={{perform this.updateTradeLocationTask trade}}


### PR DESCRIPTION
### 🐛 Problem

Since this feature is not supported by PoE's website, the /live url leads to a 404 error.

### 💊 Solution

We void rendering the button.

### 🤖 Beep beep bop

github: #61