### PR TITLE
Avoid showing up the extension when the trade site is down

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,11 +4,19 @@ import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 // Initialize the extension root container
-const isCollapsed = Boolean(window.localStorage.getItem('bt-side-panel-collapsed'));
 const extensionContainer = document.createElement('div');
 extensionContainer.id = 'better-trading-container';
-document.body.classList.add('bt-body');
-if (isCollapsed) document.body.classList.add('bt-is-collapsed');
+
+// Check if the trading app is present (ie. not in maintenance)
+if (document.querySelector('#trade')) {
+  document.body.classList.add('bt-body');
+
+  const isCollapsed = Boolean(window.localStorage.getItem('bt-side-panel-collapsed'));
+  if (isCollapsed) document.body.classList.add('bt-is-collapsed');
+} else {
+  extensionContainer.style.display = 'none';
+}
+
 document.body.appendChild(extensionContainer);
 
 const {modulePrefix, podModulePrefix} = config;

--- a/app/styles/globals/_base.scss
+++ b/app/styles/globals/_base.scss
@@ -1,4 +1,4 @@
-body {
+body.bt-body {
   overflow-y: scroll;
 
   #app {


### PR DESCRIPTION
### 🐛 Problem

The extension booted in a weird state when the trade app is down.

![image](https://user-images.githubusercontent.com/4255460/91668742-eee65a80-eadc-11ea-9ffc-f82cf7a534f9.png)

### 💊 Solution

We avoid touching the layout and hide the extension container when the `div#trade` cannot be found.

### 🤖 Beep beep bop

github: #51