### PR TITLE
Introduce the regroup-similars enhancer

### DIFF
--- a/app/services/item-results/enhance.ts
+++ b/app/services/item-results/enhance.ts
@@ -7,6 +7,7 @@ import window from 'ember-window-mock';
 import {ItemResultsEnhancerService} from 'better-trading/types/item-results';
 import HighlightStatFilters from 'better-trading/services/item-results/enhancers/highlight-stat-filters';
 import EquivalentPricings from 'better-trading/services/item-results/enhancers/equivalent-pricings';
+import RegroupSimilars from 'better-trading/services/item-results/enhancers/regroup-similars';
 import Pinnable from 'better-trading/services/item-results/enhancers/pinnable';
 import MaximumSockets from 'better-trading/services/item-results/enhancers/maximum-sockets';
 import {Task} from 'better-trading/types/ember-concurrency';
@@ -27,6 +28,9 @@ export default class ItemResultsEnhance extends Service {
   @service('item-results/enhancers/maximum-sockets')
   itemResultsEnhancersMaximumSockets: MaximumSockets;
 
+  @service('item-results/enhancers/regroup-similars')
+  itemResultsEnhancersRegroupSimilars: RegroupSimilars;
+
   resultsObserver: MutationObserver;
 
   get enhancersSequence(): ItemResultsEnhancerService[] {
@@ -34,7 +38,8 @@ export default class ItemResultsEnhance extends Service {
       this.itemResultsEnhancersHighlightStatFilters,
       this.itemResultsEnhancersEquivalentPricings,
       this.itemResultsEnhancersPinnable,
-      this.itemResultsEnhancersMaximumSockets
+      this.itemResultsEnhancersMaximumSockets,
+      this.itemResultsEnhancersRegroupSimilars
     ];
   }
 
@@ -42,7 +47,7 @@ export default class ItemResultsEnhance extends Service {
   *enhanceTask() {
     const itemElementsCount = window.document.querySelectorAll('.resultset > div.row').length;
     const unenhancedElements = Array.prototype.slice.call(
-      window.document.querySelectorAll('.resultset > div.row:not([bt-enhanced])')
+      window.document.querySelectorAll('.resultset > div.row[data-id]:not([bt-enhanced])')
     );
 
     if (unenhancedElements.length) {

--- a/app/services/item-results/enhancers/regroup-similars.ts
+++ b/app/services/item-results/enhancers/regroup-similars.ts
@@ -1,0 +1,100 @@
+// Vendor
+import Service, {inject as service} from '@ember/service';
+
+// Types
+import {ItemResultsEnhancerService} from 'better-trading/types/item-results';
+import IntlService from 'ember-intl/services/intl';
+
+export default class RegroupSimilars extends Service implements ItemResultsEnhancerService {
+  @service('intl')
+  intl: IntlService;
+
+  enhance(result: HTMLElement) {
+    const currentHash = this.setItemHash(result);
+
+    const originalResult = this.findOriginalResult(result, currentHash);
+
+    if (originalResult.dataset.id === result.dataset.id) return;
+
+    const buttonState = this.updateToggleButtonFor(originalResult);
+    result.setAttribute('bt-regroup-state', buttonState);
+  }
+
+  private findOriginalResult(result: HTMLElement, currentHash: string): HTMLElement {
+    const previousResult = result.previousElementSibling as HTMLElement;
+    if (!previousResult) return result;
+
+    const previousHash = previousResult.getAttribute('bt-regroup-hash');
+
+    if (previousHash !== currentHash) return result;
+    return this.findOriginalResult(previousResult, currentHash);
+  }
+
+  private setItemHash(result: HTMLElement) {
+    const seller = result
+      .querySelector('.pm-btn')
+      ?.getAttribute('href')
+      ?.replace(/^.+\?to=/, '');
+    const itemName = result.querySelector('.itemHeader')?.textContent?.replace(/superior/i, '');
+    const price = result.querySelector('.price')?.textContent;
+
+    const hash = btoa(
+      encodeURIComponent(
+        [seller, itemName, price]
+          .filter(Boolean)
+          .join('')
+          .replace(/\s/g, '')
+          .toLowerCase()
+      )
+    );
+    result.setAttribute('bt-regroup-hash', hash);
+
+    return hash;
+  }
+
+  private updateToggleButtonFor(result: HTMLElement) {
+    let buttonElement: HTMLButtonElement = result.querySelector('.bt-group-button') as HTMLButtonElement;
+
+    if (!buttonElement) {
+      buttonElement = document.createElement('button');
+      buttonElement.classList.add('bt-group-button');
+      buttonElement.dataset.state = 'hidden';
+      buttonElement.addEventListener('click', this.handleToggleClick.bind(this));
+
+      const detailsElement = result.querySelector('.details .pull-left');
+      detailsElement?.appendChild(buttonElement);
+    }
+
+    const currentCount = buttonElement.dataset.count;
+    const newCount = currentCount ? parseInt(currentCount, 10) + 1 : 1;
+    buttonElement.dataset.count = newCount.toString();
+
+    buttonElement.innerText = this.intl.t('item-results.regroup-similars.button', {count: newCount});
+
+    return buttonElement.dataset.state as string;
+  }
+
+  private handleToggleClick(event: MouseEvent) {
+    const buttonElement = event.target as HTMLButtonElement;
+    const resultElement = buttonElement.closest('[bt-enhanced]') as HTMLElement;
+
+    const newState = buttonElement.dataset.state === 'hidden' ? 'visible' : 'hidden';
+    buttonElement.dataset.state = newState;
+
+    return this.toggleSimilarResult(resultElement, newState, resultElement.getAttribute('bt-regroup-hash') as string);
+  }
+
+  private toggleSimilarResult(result: HTMLElement, state: string, hash: string) {
+    const nextResult = result.nextElementSibling as HTMLElement | undefined;
+    if (!nextResult || nextResult.getAttribute('bt-regroup-hash') !== hash) return;
+
+    nextResult.setAttribute('bt-regroup-state', state);
+    this.toggleSimilarResult(nextResult, state, hash);
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'item-results/enhancers/regroup-similars': RegroupSimilars;
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -19,6 +19,8 @@
 @import 'globals/search-panel';
 @import 'globals/top-button';
 @import 'globals/utility-buttons';
+@import 'globals/regroup-similars';
+@import 'globals/fixed-items-background';
 
 // Components
 @import 'pods';

--- a/app/styles/globals/_details-buttons.scss
+++ b/app/styles/globals/_details-buttons.scss
@@ -6,9 +6,23 @@
       display: block;
       float: unset !important;
     }
+  }
+}
 
+.results {
+  .btns {
+    line-height: 2;
+    //min-height: 25px;
+
+    .pull-left,
     .pull-right {
-      margin-top: 7px;
+      height: auto !important;
+    }
+
+    .pull-left {
+      .status {
+        display: inline !important;
+      }
     }
   }
 }

--- a/app/styles/globals/_fixed-items-background.scss
+++ b/app/styles/globals/_fixed-items-background.scss
@@ -1,0 +1,15 @@
+.results {
+  .row {
+    background: rgba(#202020, 0.8) !important;
+  }
+
+  &:not(.compact) {
+    .row {
+      border-bottom: 2px solid rgba($white, 0.1);
+    }
+  }
+
+  &.compact.two .row {
+    border: 1px solid #333 !important;
+  }
+}

--- a/app/styles/globals/_pinnable.scss
+++ b/app/styles/globals/_pinnable.scss
@@ -46,6 +46,7 @@
   &:hover {
     border-color: #444;
     background-color: #090909;
+    outline: none;
   }
 
   .bt-pin-button-pinned {

--- a/app/styles/globals/regroup-similars.scss
+++ b/app/styles/globals/regroup-similars.scss
@@ -1,0 +1,37 @@
+.results.compact {
+  .bt-group-button {
+    height: 18px;
+    border-color: #444;
+    line-height: 16px;
+  }
+}
+
+.bt-group-button {
+  padding: 1px 5px;
+  border: 1px solid transparent;
+  border-radius: 0;
+  margin: 8px 0 0;
+  background-color: #222;
+  text-align: center;
+  font-size: 12px;
+  font-weight: normal;
+  line-height: 1.5;
+  color: #e9cf9f;
+  cursor: pointer;
+  vertical-align: middle;
+
+  &:focus,
+  &:hover {
+    border-color: #444;
+    background-color: #090909;
+    outline: none;
+  }
+}
+
+div.row[bt-regroup-state='hidden'] {
+  display: none !important;
+}
+
+div.row[bt-regroup-state='visible'] {
+  background: rgba(#101010, 0.8) !important;
+}

--- a/translations/item-results/en.yaml
+++ b/translations/item-results/en.yaml
@@ -4,3 +4,5 @@ item-results:
     unpin: Unpin
   maximum-sockets:
     warning: 'Max. {maximum} sockets'
+  regroup-similars:
+    button: '{count, plural, =0 {} =1 {1 similar result} other {# similar results}}'


### PR DESCRIPTION
### 👨‍💻 Feature

Regroup similar items together to avoid having several identical results back to back.

- The similar results can be toggled via the "# similar result(s)" button
- 2 results are considered similar if they share the same
  - price
  - seller account
  - item name

### 👀 Preview

![Kapture 2020-09-05 at 12 38 18](https://user-images.githubusercontent.com/4255460/92309637-45d4af80-ef75-11ea-97ea-ce0591c9e277.gif)

### 🤖 Beep beep bop

github: #58