### PR TITLE
Feature for korean server, language

### DIFF
--- a/app/helpers/trade-url.ts
+++ b/app/helpers/trade-url.ts
@@ -5,7 +5,7 @@ import {inject as service} from '@ember/service';
 // Types
 import TradeLocation from 'better-trading/services/trade-location';
 
-type PositionalParams = [{slug: string; type: string}];
+type PositionalParams = [{slug: string; type: string, baseUrl?: string}];
 interface NamedParams {
   suffix?: string;
   league: string;
@@ -15,8 +15,8 @@ export default class TradeUrl extends Helper {
   @service('trade-location')
   tradeLocation: TradeLocation;
 
-  compute([{type, slug}]: PositionalParams, {suffix, league}: NamedParams) {
-    const tradeUrl = this.tradeLocation.getTradeUrl(type, slug, league);
+  compute([{type, slug, baseUrl}]: PositionalParams, {suffix, league}: NamedParams) {
+    const tradeUrl = this.tradeLocation.getTradeUrl(type, slug, league, baseUrl);
 
     if (!suffix) return tradeUrl;
 

--- a/app/helpers/trade-url.ts
+++ b/app/helpers/trade-url.ts
@@ -5,7 +5,7 @@ import {inject as service} from '@ember/service';
 // Types
 import TradeLocation from 'better-trading/services/trade-location';
 
-type PositionalParams = [{slug: string; type: string, baseUrl?: string}];
+type PositionalParams = [{slug: string; type: string; baseUrl?: string}];
 interface NamedParams {
   suffix?: string;
   league: string;

--- a/app/pods/application/route.ts
+++ b/app/pods/application/route.ts
@@ -10,7 +10,7 @@ import Storage from 'better-trading/services/storage';
 import TradeLocation from 'better-trading/services/trade-location';
 
 // Constants
-const DEFAULT_LOCALE = 'en';
+const DEFAULT_LOCALE = window.location.host.includes('pathofexile.com') ? 'en' : 'ko';
 
 export default class ApplicationRoute extends Route {
   @service('bookmarks')

--- a/app/pods/components/page/bookmarks/folder/component.ts
+++ b/app/pods/components/page/bookmarks/folder/component.ts
@@ -228,7 +228,12 @@ export default class BookmarksFolder extends Component<Args> {
   copyToClipboard(trade: BookmarksTradeStruct) {
     if (!this.currentLeague) return;
 
-    const tradeUrl = this.tradeLocation.getTradeUrl(trade.location.type, trade.location.slug, this.currentLeague, trade.location.baseUrl);
+    const tradeUrl = this.tradeLocation.getTradeUrl(
+      trade.location.type,
+      trade.location.slug,
+      this.currentLeague,
+      trade.location.baseUrl
+    );
     copyToClipboard(tradeUrl);
 
     this.flashMessages.success(

--- a/app/pods/components/page/bookmarks/folder/component.ts
+++ b/app/pods/components/page/bookmarks/folder/component.ts
@@ -163,6 +163,7 @@ export default class BookmarksFolder extends Component<Args> {
     if (!this.tradeLocation.slug || !this.tradeLocation.type) return;
 
     const initializedTrade = this.bookmarks.initializeTradeStructFrom({
+      baseUrl: this.tradeLocation.baseUrl,
       slug: this.tradeLocation.slug,
       type: this.tradeLocation.type,
     });
@@ -227,7 +228,7 @@ export default class BookmarksFolder extends Component<Args> {
   copyToClipboard(trade: BookmarksTradeStruct) {
     if (!this.currentLeague) return;
 
-    const tradeUrl = this.tradeLocation.getTradeUrl(trade.location.type, trade.location.slug, this.currentLeague);
+    const tradeUrl = this.tradeLocation.getTradeUrl(trade.location.type, trade.location.slug, this.currentLeague, trade.location.baseUrl);
     copyToClipboard(tradeUrl);
 
     this.flashMessages.success(

--- a/app/services/bookmarks/export.ts
+++ b/app/services/bookmarks/export.ts
@@ -8,6 +8,7 @@ interface ExportedFolderStruct {
   icn: string;
   tit: string;
   trs: Array<{
+    url?: string;
     tit: string;
     loc: string;
   }>;
@@ -19,17 +20,18 @@ export default class Export extends Service {
       icn: folder.icon as string,
       tit: folder.title,
       trs: trades.map((trade) => ({
+        url: trade.location.baseUrl,
         tit: trade.title,
         loc: `${trade.location.type}:${trade.location.slug}`,
       })),
     };
 
-    return btoa(JSON.stringify(payload));
+    return btoa(unescape(encodeURIComponent(JSON.stringify(payload))));
   }
 
   deserialize(serializedFolder: string): [BookmarksFolderStruct, BookmarksTradeStruct[]] | null {
     try {
-      const potentialPayload: ExportedFolderStruct = JSON.parse(atob(serializedFolder));
+      const potentialPayload: ExportedFolderStruct = JSON.parse(decodeURIComponent(escape(atob(serializedFolder))));
 
       const folder: BookmarksFolderStruct = {
         icon: potentialPayload.icn as BookmarksFolderIcon,
@@ -44,6 +46,7 @@ export default class Export extends Service {
           title: trade.tit,
           completedAt: null,
           location: {
+            baseUrl: trade.url,
             type,
             slug,
           },

--- a/app/services/trade-location.ts
+++ b/app/services/trade-location.ts
@@ -17,6 +17,7 @@ import config from 'better-trading/config/environment';
 const BASE_URL = 'https://www.pathofexile.com/trade';
 
 interface ParsedPath {
+  baseUrl?: string;
   type: string;
   league: string;
   slug?: string;
@@ -27,6 +28,12 @@ export default class TradeLocation extends Service.extend(Evented) {
   tradeLocationHistory: TradeLocationHistory;
 
   lastTradeLocation: TradeLocationStruct = this.currentTradeLocation;
+
+  get baseUrl(): string {
+    const {baseUrl} = this.parseCurrentPath();
+    
+    return baseUrl || BASE_URL;
+  }
 
   get type(): string | null {
     const {type} = this.parseCurrentPath();
@@ -48,6 +55,7 @@ export default class TradeLocation extends Service.extend(Evented) {
 
   get currentTradeLocation(): TradeLocationStruct {
     return {
+      baseUrl: this.baseUrl,
       slug: this.slug,
       type: this.type,
       league: this.league,
@@ -82,13 +90,16 @@ export default class TradeLocation extends Service.extend(Evented) {
     this.startLocationPolling();
   }
 
-  getTradeUrl(type: string, slug: string, league: string) {
-    return [BASE_URL, type, league, slug].join('/');
+  getTradeUrl(type: string, slug: string, league: string, baseUrl?: string) {
+    return [baseUrl || BASE_URL, type, league, slug].join('/');
   }
 
   compareTradeLocations(locationA: TradeLocationStruct, locationB: TradeLocationStruct) {
     return (
-      locationA.league === locationB.league && locationA.slug === locationB.slug && locationA.type === locationB.type
+      locationA.baseUrl === locationB.baseUrl &&
+      locationA.league === locationB.league &&
+      locationA.slug === locationB.slug &&
+      locationA.type === locationB.type
     );
   }
 
@@ -102,8 +113,9 @@ export default class TradeLocation extends Service.extend(Evented) {
 
   private parseCurrentPath(): ParsedPath {
     const [type, league, slug] = window.location.pathname.replace('/trade/', '').split('/');
+    const baseUrl = `${window.location.origin}/trade`;
 
-    return {type, league, slug};
+    return { baseUrl, type, league, slug};
   }
 
   private startLocationPolling() {

--- a/app/services/trade-location.ts
+++ b/app/services/trade-location.ts
@@ -31,7 +31,7 @@ export default class TradeLocation extends Service.extend(Evented) {
 
   get baseUrl(): string {
     const {baseUrl} = this.parseCurrentPath();
-    
+
     return baseUrl || BASE_URL;
   }
 
@@ -115,7 +115,7 @@ export default class TradeLocation extends Service.extend(Evented) {
     const [type, league, slug] = window.location.pathname.replace('/trade/', '').split('/');
     const baseUrl = `${window.location.origin}/trade`;
 
-    return { baseUrl, type, league, slug};
+    return {baseUrl, type, league, slug};
   }
 
   private startLocationPolling() {

--- a/app/services/trade-location/history.ts
+++ b/app/services/trade-location/history.ts
@@ -39,7 +39,7 @@ export default class TradeLocationHistory extends Service {
       id: uniqueId(),
       title: this.searchPanel.recommendTitle(),
       createdAt: new Date().toISOString(),
-    });
+    } as TradeLocationHistoryStruct);
     historyEntries.splice(config.APP.maximumHistoryLength);
 
     await this.storage.setValue(HISTORY_KEY, historyEntries);

--- a/app/types/bookmarks.ts
+++ b/app/types/bookmarks.ts
@@ -1,4 +1,5 @@
 export interface BookmarksTradeLocation {
+  baseUrl?: string;
   type: string;
   slug: string;
 }

--- a/app/types/trade-location.ts
+++ b/app/types/trade-location.ts
@@ -1,4 +1,5 @@
 export interface TradeLocationStruct {
+  baseUrl?: string,
   slug: string | null;
   type: string | null;
   league: string | null;

--- a/app/types/trade-location.ts
+++ b/app/types/trade-location.ts
@@ -1,5 +1,5 @@
 export interface TradeLocationStruct {
-  baseUrl?: string,
+  baseUrl?: string;
   slug: string | null;
   type: string | null;
   league: string | null;

--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -17,7 +17,7 @@ module.exports = function () {
      * @type {Array?}
      * @default "null"
      */
-    locales: ['en'],
+    locales: ['en', 'ko'],
 
     /**
      * autoPolyfill, when true will automatically inject the IntlJS polyfill

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -24,7 +24,10 @@ const manifest = Object.assign(
     manifest_version: 2,
     content_scripts: [
       {
-        matches: ['*://www.pathofexile.com/trade*'],
+        matches: [
+          '*://www.pathofexile.com/trade*',
+          "*://poe.game.daum.net/trade*"
+        ],
         js: [assetsPathFor('vendor.js'), assetsPathFor('better-trading.js')],
         css: [assetsPathFor('vendor.css'), assetsPathFor('better-trading.css')],
       },

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -24,10 +24,7 @@ const manifest = Object.assign(
     manifest_version: 2,
     content_scripts: [
       {
-        matches: [
-          '*://www.pathofexile.com/trade*',
-          "*://poe.game.daum.net/trade*"
-        ],
+        matches: ['*://www.pathofexile.com/trade*', '*://poe.game.daum.net/trade*'],
         js: [assetsPathFor('vendor.js'), assetsPathFor('better-trading.js')],
         css: [assetsPathFor('vendor.css'), assetsPathFor('better-trading.css')],
       },

--- a/tests/unit/services/trade-location-test.ts
+++ b/tests/unit/services/trade-location-test.ts
@@ -95,6 +95,7 @@ describe('Unit | Services | TradeLocation', () => {
             type: 'search',
             slug: 'new-trade',
             league: 'new-league',
+            baseUrl: `${window.location.origin  }/trade`,
           })
           .returns(Promise.resolve());
 
@@ -110,11 +111,13 @@ describe('Unit | Services | TradeLocation', () => {
             type: 'search',
             slug: 'initial-trade',
             league: 'initial-league',
+            baseUrl: `${window.location.origin  }/trade`,
           },
           newTradeLocation: {
             type: 'search',
             slug: 'new-trade',
             league: 'new-league',
+            baseUrl: `${window.location.origin  }/trade`,
           },
         });
       });

--- a/translations/components/ko.yaml
+++ b/translations/components/ko.yaml
@@ -1,0 +1,29 @@
+components:
+  changelog-banner:
+    notice: '새로운 버전 {version}이 설치됐습니다.'
+    modal-title: '{version} 변경점'
+    modal-button: 변경점
+    dismiss-button: 닫기
+  clipboard-textarea:
+    button: 클립보드에 복사
+    button-copied: 복사됨
+  root-page-menu:
+    bookmarks: 즐겨찾기
+    history: 기록
+    pinned-items: 고정됨
+  the-forbidden-trove:
+    credits: Powered by The Forbidden Trove
+    close: Close
+    blacklist-warning:
+      title: Blacklisted account
+      body: '{accountName} has been reported {timeAgo}.'
+      reason: 'Logged reason:'
+      disclaimer: The whisper message has still been copied to your clipboard, you can proceed with the trade.
+    pending-report:
+      title: Report a fraudulent trade
+      warning: Make sure the reported issue is really a scam. False reports wont be tolerated by TFT's moderators.
+      steps:
+        1: Log into
+        1-link: TFT's Discord server
+        2: 'Paste the pre-generated message into the #scam-report-psa channel'
+        3: Fill the "transcript of the event" and "proof" to help the moderation team

--- a/translations/general/ko.yaml
+++ b/translations/general/ko.yaml
@@ -1,0 +1,3 @@
+general:
+  title: Better Trading
+  generic-alert-flash: 앗! 무언가 잘못됐습니다!

--- a/translations/item-results/ko.yaml
+++ b/translations/item-results/ko.yaml
@@ -1,0 +1,10 @@
+item-results:
+  reportable:
+    report: TFT에 신고
+  pinnable:
+    pin: 고정
+    unpin: 해제
+  maximum-sockets:
+    warning: '최대. {maximum} 소켓'
+  regroup-similars:
+    button: '{count, plural, =0 {} =1 {1개의 유사한 결과} other {#개의 유사한 결과들}}'

--- a/translations/page/about/ko.yaml
+++ b/translations/page/about/ko.yaml
@@ -1,0 +1,15 @@
+page:
+  about:
+    disclaimer: This extension is fan-made and not affiliated with Grinding Gear Games in any way. 
+    enhancers:
+      title: Enabled item result enhancers
+      equivalent-pricings: Equivalent pricings (powered by poe.ninja)
+      highlight-stat-filters: Highlight searched mods
+      maximum-sockets: Warning for armors that cannot by 6-socketed
+      regroup-similars: Regroup similar results
+      tft-reportable: Report button (powered by TFT)
+      tft-scam-prevention: Warning against blacklisted users (powered by TFT)
+    github:
+      title: On GitHub
+      description: To contribute, report issues or simply browse the code.
+      button: View on GitHub

--- a/translations/page/bookmarks/ko.yaml
+++ b/translations/page/bookmarks/ko.yaml
@@ -1,0 +1,71 @@
+page:
+  bookmarks:
+    create-folder: 새 폴더
+    import-folder: 폴더 가져오기
+    collapse-all: 폴더 모두 접기
+    show-archived-folders: 폴더 보관
+    show-unarchived-folders: 활성화된 폴더로 돌아가기
+    folders-warning: 너무 많은 폴더는 페이지를 느리게 할 수 있습니다.<br>불필요한 폴더를 내보내기하여 백업한 뒤, 제거해주세요.
+    delete-folder-success-flash: '"{title}"폴더가 제거됐습니다.'
+    update-folder-success-flash: '"{title}"폴더가 갱신됐습니다.'
+    create-folder-success-flash: '"{title}"폴더가 생성됐습니다.'
+    import-folder-success-flash: '"{title}"폴더를 가져왔습니다.'
+    backup:
+      title: 백업 도구
+      generate-button: 파일로 저장
+      restore-button: 파일에서 가져오기
+      restore-error-flash: 백업에서 복구를 실패했습니다.
+    folder:
+      edit-folder: 수정
+      delete-folder: 삭제
+      archive-folder: 보관
+      restore-folder: 복구
+      export-folder: 내보내기/공유
+      open-live-trade: 라이브 서치
+      create-trade: 현재 트레이드를 등록
+      copy-trade-to-clipboard: 트레이드 URL을 클립보드에 복사
+      copy-trade-to-clipboard-success-flash: '"{title}"의 트레이드 URL이 클립보드에 복사됐습니다.'
+      edit-trade: 수정
+      delete-trade: 삭제
+      update-trade-location: 현재 트레이드로 저장
+      complete-trade: 완료로 표시
+      uncomplete-trade: 미완료로 표시
+      delete-trade-success-flash: '"{title}" 트레이드가 제거됐습니다.'
+      update-trade-success-flash: '"{title}" 트레이드가 업데이트됐습니다.'
+      create-trade-success-flash: '"{title}" 트레이드가 생성됐습니다.'
+      persist-trade-location-success-flash: '"{title}" 트레이드 경로가 업데이트 됐습니다.'
+      trade-deletion:
+        modal-title: 삭제 확인
+        confirmation: '정말로 트레이드 <strong>{name}</strong>를 삭제하시겠습니까?'
+        delete: 삭제
+        cancel: 취소
+      folder-deletion:
+        modal-title: 삭제 확인
+        confirmation: '정말로 즐겨찾기 폴더 <strong>{name}</strong>{tradesCount, plural, =0 {} =1 {와 <strong>한 개의 즐겨찾기</strong>} other {와 <strong># 개의 즐겨찾기</strong>}}를 삭제하시겠습니까?'
+        delete: 삭제
+        cancel: 취소
+      folder-export:
+        modal-title: 즐겨찾기 폴더 내보내기
+        preview-url: 미리보기 페이지
+        preview-url-button: 새 탭에서 열기
+        export-code: 코드 내보내기
+        export-code-helper: 이 코드는 폴더를 복구할 수 있습니다. 백업과 공유를 목적으로 사용될 수 있습니다.
+        embed-code: Embed code snippet
+        embed-code-helper: Code snippet that can be used to include the folder's preview into a website.
+        close: 닫기
+      trade-edition:
+        modal-title: 트레이드 즐겨찾기
+        title-label: 제목
+        save: 저장
+    folder-edition:
+      modal-title: 즐겨찾기 폴더
+      title-label: 제목
+      icon-label: 아이콘
+      save: 저장
+    folder-import:
+      modal-title: 즐겨찾기 폴더 가져오기
+      import-code:
+        label: 코드 가져오기
+      preview: '{name} {tradesCount, plural, =0 {} =1 {(1 개의 즐겨찾기)} other {(#개의 즐겨찾기)}}'
+      invalid-code: 입력된 코드가 유효하지 않습니다. 다른 코드를 입력해주세요.
+      save: 저장

--- a/translations/page/history/ko.yaml
+++ b/translations/page/history/ko.yaml
@@ -1,0 +1,5 @@
+page:
+  history:
+    clear: 기록 초기화
+    empty: 검색 기록이 비어있습니다.
+    clear-success-flash: 검색 기록이 초기화됐습니다.

--- a/translations/page/pinned-items/ko.yaml
+++ b/translations/page/pinned-items/ko.yaml
@@ -1,0 +1,7 @@
+page:
+  pinned-items:
+    warning: 고정된 아이템은 현재 검색된 결과에서만 나타납니다. 새로 검색하게 되는 경우 현재 고정된 아이템은 모두 초기화됩니다.
+    clear: 고정된 아이템 초기화
+    empty: 고정 버튼을 눌러 아이템을 고정할 수 있습니다.
+    unpin-item: 해제
+    scroll-to-item: 아이템으로 스크롤


### PR DESCRIPTION
1. Update manifest for korean server [https://poe.game.daum.net/](https://poe.game.daum.net/) (pretty different from US server.)
2. Update **getTradeUrl** and **TradeLocation** optional argument - baseUrl. (Because of slug depends on language, search history needs to archieve host url.)
3. Korean language translation
4. Fix bookmark export/import for unicode.