### PR TITLE
feat: update trade search page titles based on active trade

### DIFF
--- a/app/pods/application/route.ts
+++ b/app/pods/application/route.ts
@@ -8,6 +8,7 @@ import IntlService from 'ember-intl/services/intl';
 import Bookmarks from 'better-trading/services/bookmarks';
 import Storage from 'better-trading/services/storage';
 import TradeLocation from 'better-trading/services/trade-location';
+import PageTitle from 'better-trading/services/page-title';
 
 // Constants
 const DEFAULT_LOCALE = 'en';
@@ -28,10 +29,14 @@ export default class ApplicationRoute extends Route {
   @service('trade-location')
   tradeLocation: TradeLocation;
 
+  @service('page-title')
+  pageTitle: PageTitle;
+
   async beforeModel() {
     this.intl.setLocale(DEFAULT_LOCALE);
     await this.itemResults.initialize();
     this.tradeLocation.initialize();
     await this.storage.initialize();
+    await this.pageTitle.initialize();
   }
 }

--- a/app/services/bookmarks.ts
+++ b/app/services/bookmarks.ts
@@ -7,7 +7,12 @@ import BookmarksState from 'better-trading/services/bookmarks/state';
 import BookmarksStorage from 'better-trading/services/bookmarks/storage';
 import BookmarksExport from 'better-trading/services/bookmarks/export';
 import BookmarksBackup from 'better-trading/services/bookmarks/backup';
-import {BookmarksFolderStruct, BookmarksTradeLocation, BookmarksTradeStruct, PartialBookmarksTradeLocation} from 'better-trading/types/bookmarks';
+import {
+  BookmarksFolderStruct,
+  BookmarksTradeLocation,
+  BookmarksTradeStruct,
+  PartialBookmarksTradeLocation,
+} from 'better-trading/types/bookmarks';
 
 export default class Bookmarks extends Service.extend(Evented) {
   @service('bookmarks/storage')
@@ -33,24 +38,25 @@ export default class Bookmarks extends Service.extend(Evented) {
   async fetchTradeByLocation(location: PartialBookmarksTradeLocation): Promise<BookmarksTradeStruct | null> {
     const folders = await this.fetchFolders();
     const foldersWithTrades = await Promise.all(
-      folders.map(async folder => ({
+      folders.map(async (folder) => ({
         ...folder,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        trades: await this.fetchTradesByFolderId(folder.id!)
-      })));
-    const matches = foldersWithTrades
-      .map(folderWithTrades => ({
-        ...folderWithTrades,
-        trades: folderWithTrades.trades.filter(trade =>
-          trade.location.slug === location.slug &&
-          trade.location.type === location.type)
+        trades: await this.fetchTradesByFolderId(folder.id!),
       }))
-      .filter(f => f.trades.length > 0);
-    const unarchivedMatches = matches.filter(m => m.archivedAt);
+    );
+    const matches = foldersWithTrades
+      .map((folderWithTrades) => ({
+        ...folderWithTrades,
+        trades: folderWithTrades.trades.filter(
+          (trade) => trade.location.slug === location.slug && trade.location.type === location.type
+        ),
+      }))
+      .filter((f) => f.trades.length > 0);
+    const unarchivedMatches = matches.filter((m) => m.archivedAt);
 
     if (unarchivedMatches.length > 0) {
       return unarchivedMatches[0].trades[0];
-    } else if(matches.length > 0) {
+    } else if (matches.length > 0) {
       return matches[0].trades[0];
     } else {
       return null;

--- a/app/services/bookmarks.ts
+++ b/app/services/bookmarks.ts
@@ -1,14 +1,15 @@
 // Vendor
 import Service, {inject as service} from '@ember/service';
+import Evented from '@ember/object/evented';
 
 // Types
 import BookmarksState from 'better-trading/services/bookmarks/state';
 import BookmarksStorage from 'better-trading/services/bookmarks/storage';
 import BookmarksExport from 'better-trading/services/bookmarks/export';
 import BookmarksBackup from 'better-trading/services/bookmarks/backup';
-import {BookmarksFolderStruct, BookmarksTradeLocation, BookmarksTradeStruct} from 'better-trading/types/bookmarks';
+import {BookmarksFolderStruct, BookmarksTradeLocation, BookmarksTradeStruct, PartialBookmarksTradeLocation} from 'better-trading/types/bookmarks';
 
-export default class Bookmarks extends Service {
+export default class Bookmarks extends Service.extend(Evented) {
   @service('bookmarks/storage')
   bookmarksStorage: BookmarksStorage;
 
@@ -29,32 +30,69 @@ export default class Bookmarks extends Service {
     return this.bookmarksStorage.fetchTradesByFolderId(folderId);
   }
 
+  async fetchTradeByLocation(location: PartialBookmarksTradeLocation): Promise<BookmarksTradeStruct | null> {
+    const folders = await this.fetchFolders();
+    const foldersWithTrades = await Promise.all(
+      folders.map(async folder => ({
+        ...folder,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        trades: await this.fetchTradesByFolderId(folder.id!)
+      })));
+    const matches = foldersWithTrades
+      .map(folderWithTrades => ({
+        ...folderWithTrades,
+        trades: folderWithTrades.trades.filter(trade =>
+          trade.location.slug === location.slug &&
+          trade.location.type === location.type)
+      }))
+      .filter(f => f.trades.length > 0);
+    const unarchivedMatches = matches.filter(m => m.archivedAt);
+
+    if (unarchivedMatches.length > 0) {
+      return unarchivedMatches[0].trades[0];
+    } else if(matches.length > 0) {
+      return matches[0].trades[0];
+    } else {
+      return null;
+    }
+  }
+
   async persistFolder(bookmarkFolder: BookmarksFolderStruct) {
-    return this.bookmarksStorage.persistFolder(bookmarkFolder);
+    const newId = await this.bookmarksStorage.persistFolder(bookmarkFolder);
+    this.trigger('change');
+    return newId;
   }
 
   async persistFolders(bookmarkFolders: BookmarksFolderStruct[]) {
-    return this.bookmarksStorage.persistFolders(bookmarkFolders);
+    const newId = await this.bookmarksStorage.persistFolders(bookmarkFolders);
+    this.trigger('change');
+    return newId;
   }
 
   async persistTrade(bookmarkTrade: BookmarksTradeStruct, folderId: string) {
-    return this.bookmarksStorage.persistTrade(bookmarkTrade, folderId);
+    const newId = await this.bookmarksStorage.persistTrade(bookmarkTrade, folderId);
+    this.trigger('change');
+    return newId;
   }
 
   async persistTrades(bookmarkTrades: BookmarksTradeStruct[], folderId: string) {
-    return this.bookmarksStorage.persistTrades(bookmarkTrades, folderId);
+    const newId = await this.bookmarksStorage.persistTrades(bookmarkTrades, folderId);
+    this.trigger('change');
+    return newId;
   }
 
   async deleteTrade(deletingTrade: BookmarksTradeStruct, folderId: string) {
     if (!deletingTrade.id) return;
 
-    return this.bookmarksStorage.deleteTrade(deletingTrade.id, folderId);
+    await this.bookmarksStorage.deleteTrade(deletingTrade.id, folderId);
+    this.trigger('change');
   }
 
   async deleteFolder(deletingFolder: BookmarksFolderStruct) {
     if (!deletingFolder.id) return;
 
-    return this.bookmarksStorage.deleteFolder(deletingFolder.id);
+    await this.bookmarksStorage.deleteFolder(deletingFolder.id);
+    this.trigger('change');
   }
 
   async toggleTradeCompletion(trade: BookmarksTradeStruct, folderId: string) {

--- a/app/services/page-title.ts
+++ b/app/services/page-title.ts
@@ -75,7 +75,6 @@ export default class PageTitle extends Service {
 
   private onDocumentTitleMutation(): void {
     if (this.title != null && document.title !== this.title) {
-      this.baseSiteTitle = document.title;
       document.title = this.title;
     }
   }

--- a/app/services/page-title.ts
+++ b/app/services/page-title.ts
@@ -1,0 +1,72 @@
+// Vendor
+import Service from '@ember/service';
+import {inject as service} from '@ember/service';
+
+// Types
+import Bookmarks from './bookmarks';
+import SearchPanel from './search-panel';
+import TradeLocation from './trade-location';
+
+export default class PageTitle extends Service {
+  @service('bookmarks')
+  bookmarks: Bookmarks;
+
+  @service('trade-location')
+  tradeLocation: TradeLocation;
+
+  @service('search-panel')
+  searchPanel: SearchPanel;
+
+  // null implies "uncontrolled by the service"
+  private _title: string | null = null;
+  private _baseSiteTitle: string = '';
+  private _titleObserver: MutationObserver;
+
+  async initialize(): Promise<void> {
+    const titleElement = document.querySelector("title")
+    if (!titleElement) { return; }
+    this._baseSiteTitle = document.title;
+
+    // The observer is to counteract the trade site's native behavior of regularly
+    // resetting the document title in response to various UI interactions
+    this._titleObserver = new MutationObserver(() => { this.onDocumentTitleMutation() });
+    this._titleObserver.observe(titleElement, { childList: true });
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.bookmarks.on('change', () => { this.recalculateTitle(); });
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.tradeLocation.on('change', () => { this.recalculateTitle(); });
+
+    await this.recalculateTitle();
+  }
+
+  private async recalculateTitle(): Promise<void> {
+    const activeBookmark = await this.bookmarks.fetchTradeByLocation(this.tradeLocation.currentTradeLocation);
+
+    const isLiveSegment = this.tradeLocation.isLive ? '⚡ ' : ''
+    const activeTradeTitle = activeBookmark ? activeBookmark.title : this.searchPanel.recommendTitle();
+    const tradeTitleSegment = activeTradeTitle ? `${activeTradeTitle} - ` : '';
+
+    this.title = `${isLiveSegment}${tradeTitleSegment}${this._baseSiteTitle}`;
+  }
+
+  set title(value: string) {
+    if (value !== this._title) {
+      this._title = value;
+      document.title = value;
+    }
+  }
+
+  private onDocumentTitleMutation(): void {
+    if(this._title != null && document.title !== this._title) {
+      this._baseSiteTitle = document.title;
+      document.title = this._title;
+    }
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'page-title': PageTitle;
+  }
+}

--- a/app/services/page-title.ts
+++ b/app/services/page-title.ts
@@ -23,19 +23,28 @@ export default class PageTitle extends Service {
   private _titleObserver: MutationObserver;
 
   async initialize(): Promise<void> {
-    const titleElement = document.querySelector("title")
-    if (!titleElement) { return; }
+    const titleElement = document.querySelector('title');
+    if (!titleElement) {
+      return;
+    }
     this._baseSiteTitle = document.title;
 
     // The observer is to counteract the trade site's native behavior of regularly
     // resetting the document title in response to various UI interactions
-    this._titleObserver = new MutationObserver(() => { this.onDocumentTitleMutation() });
-    this._titleObserver.observe(titleElement, { childList: true });
+    this._titleObserver = new MutationObserver(() => {
+      this.onDocumentTitleMutation();
+    });
+    this._titleObserver.observe(titleElement, {childList: true});
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.bookmarks.on('change', () => { this.recalculateTitle(); });
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.tradeLocation.on('change', () => { this.recalculateTitle(); });
+    // It's okay for multiple floating recalculateTitle() promises to race each other
+    this.bookmarks.on('change', () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.recalculateTitle();
+    });
+    this.tradeLocation.on('change', () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.recalculateTitle();
+    });
 
     await this.recalculateTitle();
   }
@@ -43,7 +52,7 @@ export default class PageTitle extends Service {
   private async recalculateTitle(): Promise<void> {
     const activeBookmark = await this.bookmarks.fetchTradeByLocation(this.tradeLocation.currentTradeLocation);
 
-    const isLiveSegment = this.tradeLocation.isLive ? '⚡ ' : ''
+    const isLiveSegment = this.tradeLocation.isLive ? '⚡ ' : '';
     const activeTradeTitle = activeBookmark ? activeBookmark.title : this.searchPanel.recommendTitle();
     const tradeTitleSegment = activeTradeTitle ? `${activeTradeTitle} - ` : '';
 
@@ -58,7 +67,7 @@ export default class PageTitle extends Service {
   }
 
   private onDocumentTitleMutation(): void {
-    if(this._title != null && document.title !== this._title) {
+    if (this._title != null && document.title !== this._title) {
       this._baseSiteTitle = document.title;
       document.title = this._title;
     }

--- a/app/services/trade-location.ts
+++ b/app/services/trade-location.ts
@@ -6,7 +6,11 @@ import {timeout} from 'ember-concurrency';
 import Evented from '@ember/object/evented';
 
 // Types
-import {TradeLocationChangeEvent, TradeLocationStruct} from 'better-trading/types/trade-location';
+import {
+  ExactTradeLocationStruct,
+  TradeLocationChangeEvent,
+  TradeLocationStruct,
+} from 'better-trading/types/trade-location';
 import {Task} from 'better-trading/types/ember-concurrency';
 import TradeLocationHistory from 'better-trading/services/trade-location/history';
 
@@ -20,7 +24,7 @@ export default class TradeLocation extends Service.extend(Evented) {
   @service('trade-location/history')
   tradeLocationHistory: TradeLocationHistory;
 
-  lastTradeLocation: TradeLocationStruct = this.currentTradeLocation;
+  lastTradeLocation: ExactTradeLocationStruct = this.currentTradeLocation;
 
   get type(): string | null {
     return this.currentTradeLocation.type;
@@ -38,7 +42,7 @@ export default class TradeLocation extends Service.extend(Evented) {
     return this.currentTradeLocation.isLive;
   }
 
-  get currentTradeLocation(): TradeLocationStruct {
+  get currentTradeLocation(): ExactTradeLocationStruct {
     return this.parseCurrentPath();
   }
 
@@ -46,7 +50,7 @@ export default class TradeLocation extends Service.extend(Evented) {
   *locationPollingTask() {
     const currentTradeLocation = this.currentTradeLocation;
 
-    if (!this.compareTradeLocationsIncludingLiveness(this.lastTradeLocation, currentTradeLocation)) {
+    if (!this.compareExactTradeLocations(this.lastTradeLocation, currentTradeLocation)) {
       const changeEvent: TradeLocationChangeEvent = {
         oldTradeLocation: this.lastTradeLocation,
         newTradeLocation: currentTradeLocation,
@@ -80,7 +84,7 @@ export default class TradeLocation extends Service.extend(Evented) {
     );
   }
 
-  compareTradeLocationsIncludingLiveness(locationA: TradeLocationStruct, locationB: TradeLocationStruct) {
+  compareExactTradeLocations(locationA: ExactTradeLocationStruct, locationB: ExactTradeLocationStruct) {
     return this.compareTradeLocations(locationA, locationB) && locationA.isLive === locationB.isLive;
   }
 
@@ -92,13 +96,13 @@ export default class TradeLocation extends Service.extend(Evented) {
     return this.tradeLocationHistory.clearHistoryEntries();
   }
 
-  private parseCurrentPath(): TradeLocationStruct {
+  private parseCurrentPath(): ExactTradeLocationStruct {
     const [type, league, slug, live] = window.location.pathname.replace('/trade/', '').split('/');
 
     return {
-      type: type ?? null,
-      league: league ?? null,
-      slug: slug ?? null,
+      type: type || null,
+      league: league || null,
+      slug: slug || null,
       isLive: live === 'live',
     };
   }

--- a/app/services/trade-location.ts
+++ b/app/services/trade-location.ts
@@ -76,9 +76,7 @@ export default class TradeLocation extends Service.extend(Evented) {
 
   compareTradeLocations(locationA: TradeLocationStruct, locationB: TradeLocationStruct) {
     return (
-      locationA.league === locationB.league &&
-      locationA.slug === locationB.slug &&
-      locationA.type === locationB.type
+      locationA.league === locationB.league && locationA.slug === locationB.slug && locationA.type === locationB.type
     );
   }
 
@@ -101,7 +99,7 @@ export default class TradeLocation extends Service.extend(Evented) {
       type: type ?? null,
       league: league ?? null,
       slug: slug ?? null,
-      isLive: live === "live"
+      isLive: live === 'live',
     };
   }
 

--- a/app/types/bookmarks.ts
+++ b/app/types/bookmarks.ts
@@ -3,6 +3,11 @@ export interface BookmarksTradeLocation {
   slug: string;
 }
 
+export interface PartialBookmarksTradeLocation {
+  type: string | null;
+  slug: string | null;
+}
+
 export interface BookmarksTradeStruct {
   id?: string;
   title: string;

--- a/app/types/trade-location.ts
+++ b/app/types/trade-location.ts
@@ -2,6 +2,7 @@ export interface TradeLocationStruct {
   slug: string | null;
   type: string | null;
   league: string | null;
+  isLive: boolean;
 }
 
 export interface TradeLocationChangeEvent {

--- a/app/types/trade-location.ts
+++ b/app/types/trade-location.ts
@@ -2,6 +2,9 @@ export interface TradeLocationStruct {
   slug: string | null;
   type: string | null;
   league: string | null;
+}
+
+export interface ExactTradeLocationStruct extends TradeLocationStruct {
   isLive: boolean;
 }
 

--- a/changelogs/1-6-0-new-maintainer.md
+++ b/changelogs/1-6-0-new-maintainer.md
@@ -5,6 +5,8 @@ BetterTrading has found a new maintainer! For bug reports or feature requests, [
 ## New features ✨
 
 - Divine Orbs have replaced Exalted Orbs in the "Equivalent Price" display on trade results
+- Better page/tab titles for trade searchs! If you have the current trade bookmarked, it will use the bookmark's name - otherwise, it will try to infer one based on your search filters
+- Live search page/tab titles are now prefixed with a ⚡ icon
 
 ## Improvements 💅
 

--- a/tests/unit/services/bookmarks-test.ts
+++ b/tests/unit/services/bookmarks-test.ts
@@ -1,0 +1,106 @@
+// Vendor
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import sinon from 'sinon';
+
+// Types
+import Bookmarks from 'better-trading/services/bookmarks';
+import {BookmarksFolderStruct, BookmarksTradeStruct} from 'better-trading/types/bookmarks';
+
+describe('Unit | Services | Bookmarks', () => {
+  setupTest();
+
+  let service: Bookmarks;
+  let bookmarksStorageMock: sinon.SinonMock;
+
+  beforeEach(function () {
+    service = this.owner.lookup('service:bookmarks');
+    bookmarksStorageMock = sinon.mock(service.bookmarksStorage);
+  });
+
+  afterEach(() => {
+    bookmarksStorageMock.verify();
+  });
+
+  describe('fetchTradeByLocation', () => {
+    const setupFakeTrades = (tradesByFolderId: Record<string, Array<Partial<BookmarksTradeStruct>>>): void => {
+      const fakeFolders: BookmarksFolderStruct[] = Object.keys(tradesByFolderId).map((id) => ({
+        id,
+        title: `Title ${id}`,
+        icon: null,
+        archivedAt: id.startsWith('archived') ? 'some timestamp' : null,
+      }));
+      bookmarksStorageMock.expects('fetchFolders').once().returns(Promise.resolve(fakeFolders));
+
+      for (const fakeFolderId in tradesByFolderId) {
+        bookmarksStorageMock
+          .expects('fetchTradesByFolderId')
+          .once()
+          .withArgs(fakeFolderId)
+          .returns(Promise.resolve(tradesByFolderId[fakeFolderId]));
+      }
+    };
+
+    it('should return null if no trade matches the given location', async () => {
+      setupFakeTrades({});
+
+      const result = await service.fetchTradeByLocation({type: 'search', slug: 'unknown-slug'});
+
+      expect(result).to.be.null;
+    });
+
+    it('should return corresponding trade when a single match exists', async () => {
+      setupFakeTrades({
+        folder1: [
+          {id: 'trade1', title: 'Trade 1', location: {type: 'search', slug: 'slug1'}},
+          {id: 'trade2', title: 'Trade 2', location: {type: 'search', slug: 'slug2'}},
+        ],
+      });
+
+      const result = await service.fetchTradeByLocation({type: 'search', slug: 'slug1'});
+
+      expect(result).not.to.be.null;
+      if (!result) return;
+      expect(result.id).to.equal('trade1');
+      expect(result.title).to.equal('Trade 1');
+    });
+
+    it('should return trade with alphabetically first title when multiple matches exists', async () => {
+      setupFakeTrades({
+        folder1: [
+          {id: 'matching-id-1', title: 'alphabetically later', location: {type: 'search', slug: 'matching-slug'}},
+          {
+            id: 'unrelated-id',
+            title: 'aaalphabetically earliest, but wrong location',
+            location: {type: 'search', slug: 'unrelated-slug'},
+          },
+        ],
+        folder2: [
+          {id: 'matching-id-2', title: 'alphabetically earlier', location: {type: 'search', slug: 'matching-slug'}},
+        ],
+      });
+
+      const result = await service.fetchTradeByLocation({type: 'search', slug: 'matching-slug'});
+
+      expect(result).not.to.be.null;
+      if (!result) return;
+      expect(result.id).to.equal('matching-id-2');
+      expect(result.title).to.equal('alphabetically earlier');
+    });
+
+    it('should prefer unarchived trades to archived ones', async () => {
+      setupFakeTrades({
+        'archived-folder': [{id: 'archived-trade', title: 'Archived Trade', location: {type: 'search', slug: 'slug1'}}],
+        'current-folder': [{id: 'current-trade', title: 'Current Trade', location: {type: 'search', slug: 'slug1'}}],
+      });
+
+      const result = await service.fetchTradeByLocation({type: 'search', slug: 'slug1'});
+
+      expect(result).not.to.be.null;
+      if (!result) return;
+      expect(result.id).to.equal('current-trade');
+      expect(result.title).to.equal('Current Trade');
+    });
+  });
+});

--- a/tests/unit/services/page-title-test.ts
+++ b/tests/unit/services/page-title-test.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 // Types
 import PageTitle from 'better-trading/services/page-title';
 import TradeLocation from 'better-trading/services/trade-location';
-import { ExactTradeLocationStruct } from 'better-trading/types/trade-location';
+import {ExactTradeLocationStruct} from 'better-trading/types/trade-location';
 
 describe('Unit | Services | PageTitle', () => {
   setupTest();
@@ -15,15 +15,15 @@ describe('Unit | Services | PageTitle', () => {
   let service: PageTitle;
   let bookmarksMock: sinon.SinonMock;
   let searchPanelMock: sinon.SinonMock;
-  let currentLocationStub: Partial<ExactTradeLocationStruct>
+  let currentLocationStub: Partial<ExactTradeLocationStruct>;
 
   beforeEach(function () {
     service = this.owner.lookup('service:page-title');
     service.baseSiteTitle = 'Base Site Title';
     bookmarksMock = sinon.mock(service.bookmarks);
     searchPanelMock = sinon.mock(service.searchPanel);
-    currentLocationStub = { type: null };
-    service.tradeLocation = { currentTradeLocation: currentLocationStub } as TradeLocation;
+    currentLocationStub = {type: null};
+    service.tradeLocation = {currentTradeLocation: currentLocationStub} as TradeLocation;
   });
 
   afterEach(() => {
@@ -63,7 +63,7 @@ describe('Unit | Services | PageTitle', () => {
     it('uses the search panel recommended title if there is no current bookmark', async () => {
       currentLocationStub.type = 'search';
       currentLocationStub.isLive = false;
-      
+
       bookmarksMock.expects('fetchTradeByLocation').once().withArgs(currentLocationStub).returns(Promise.resolve(null));
       searchPanelMock.expects('recommendTitle').once().returns('Search Panel Recommendation');
 

--- a/tests/unit/services/page-title-test.ts
+++ b/tests/unit/services/page-title-test.ts
@@ -1,0 +1,99 @@
+// Vendor
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import sinon from 'sinon';
+
+// Types
+import PageTitle from 'better-trading/services/page-title';
+import TradeLocation from 'better-trading/services/trade-location';
+import { ExactTradeLocationStruct } from 'better-trading/types/trade-location';
+
+describe('Unit | Services | PageTitle', () => {
+  setupTest();
+
+  let service: PageTitle;
+  let bookmarksMock: sinon.SinonMock;
+  let searchPanelMock: sinon.SinonMock;
+  let currentLocationStub: Partial<ExactTradeLocationStruct>
+
+  beforeEach(function () {
+    service = this.owner.lookup('service:page-title');
+    service.baseSiteTitle = 'Base Site Title';
+    bookmarksMock = sinon.mock(service.bookmarks);
+    searchPanelMock = sinon.mock(service.searchPanel);
+    currentLocationStub = { type: null };
+    service.tradeLocation = { currentTradeLocation: currentLocationStub } as TradeLocation;
+  });
+
+  afterEach(() => {
+    bookmarksMock.verify();
+    searchPanelMock.verify();
+  });
+
+  describe('calculateTitle', () => {
+    it('adds a ⚡ prefix to live searches', async () => {
+      currentLocationStub.type = 'search';
+      currentLocationStub.isLive = true;
+
+      bookmarksMock.expects('fetchTradeByLocation').once().returns(Promise.resolve(null));
+      searchPanelMock.expects('recommendTitle').once().returns('');
+
+      const result = await service.calculateTitle();
+
+      expect(result).to.equal('⚡ Base Site Title');
+    });
+
+    it('uses the current bookmark title if available', async () => {
+      currentLocationStub.type = 'search';
+      currentLocationStub.isLive = false;
+
+      bookmarksMock
+        .expects('fetchTradeByLocation')
+        .once()
+        .withArgs(currentLocationStub)
+        .returns(Promise.resolve({title: 'Bookmark Title'}));
+      searchPanelMock.expects('recommendTitle').never();
+
+      const result = await service.calculateTitle();
+
+      expect(result).to.equal('Bookmark Title - Base Site Title');
+    });
+
+    it('uses the search panel recommended title if there is no current bookmark', async () => {
+      currentLocationStub.type = 'search';
+      currentLocationStub.isLive = false;
+      
+      bookmarksMock.expects('fetchTradeByLocation').once().withArgs(currentLocationStub).returns(Promise.resolve(null));
+      searchPanelMock.expects('recommendTitle').once().returns('Search Panel Recommendation');
+
+      const result = await service.calculateTitle();
+
+      expect(result).to.equal('Search Panel Recommendation - Base Site Title');
+    });
+
+    it('falls back to the base site title', async () => {
+      currentLocationStub.type = 'search';
+      currentLocationStub.isLive = false;
+
+      bookmarksMock.expects('fetchTradeByLocation').once().withArgs(currentLocationStub).returns(Promise.resolve(null));
+      searchPanelMock.expects('recommendTitle').once().returns('');
+
+      const result = await service.calculateTitle();
+
+      expect(result).to.equal('Base Site Title');
+    });
+
+    it('does not query the search panel for non-search locations', async () => {
+      currentLocationStub.type = 'exchange';
+      currentLocationStub.isLive = false;
+
+      bookmarksMock.expects('fetchTradeByLocation').once().withArgs(currentLocationStub).returns(Promise.resolve(null));
+      searchPanelMock.expects('recommendTitle').never();
+
+      const result = await service.calculateTitle();
+
+      expect(result).to.equal('Base Site Title');
+    });
+  });
+});

--- a/tests/unit/services/trade-location-test.ts
+++ b/tests/unit/services/trade-location-test.ts
@@ -27,6 +27,64 @@ describe('Unit | Services | TradeLocation', () => {
     tradeLocationHistoryMock.verify();
   });
 
+  describe('get type', () => {
+    it('should return null from the unresolved redirect URL', () => {
+      window.location.pathname = '/trade';
+
+      expect(service.type).to.be.null;
+    });
+
+    it('should return search from the base URL', () => {
+      window.location.pathname = '/trade/search/Legion';
+
+      expect(service.type).to.equal('search');
+    });
+
+    it('should return search from a trade URL', () => {
+      window.location.pathname = '/trade/search/Legion/q1w2e3r4t5';
+
+      expect(service.type).to.equal('search');
+    });
+
+    it('should return exchange from a bulk exchange URL', () => {
+      window.location.pathname = '/trade/exchange/Legion/q1w2e3r4t5';
+
+      expect(service.type).to.equal('exchange');
+    });
+
+    it('should return search from a live search URL', () => {
+      window.location.pathname = '/trade/search/Legion/q1w2e3r4t5/live';
+
+      expect(service.type).to.equal('search');
+    });
+  });
+
+  describe('get isLive', () => {
+    it('should return false from the base URL', () => {
+      window.location.pathname = '/trade/search/Legion';
+
+      expect(service.isLive).to.be.false;
+    });
+
+    it('should return false from a trade URL', () => {
+      window.location.pathname = '/trade/search/Legion/q1w2e3r4t5';
+
+      expect(service.isLive).to.be.false;
+    });
+
+    it('should return false from a bulk exchange URL', () => {
+      window.location.pathname = '/trade/exchange/Legion/q1w2e3r4t5';
+
+      expect(service.isLive).to.be.false;
+    });
+
+    it('should return true from a live search URL', () => {
+      window.location.pathname = '/trade/search/Legion/q1w2e3r4t5/live';
+
+      expect(service.isLive).to.be.true;
+    });
+  });
+
   describe('get league', () => {
     it('should returns the active league from the base URL', () => {
       window.location.pathname = '/trade/search/Legion';
@@ -42,6 +100,12 @@ describe('Unit | Services | TradeLocation', () => {
 
     it('should returns the active league from a bulk exchange URL', () => {
       window.location.pathname = '/trade/exchange/Legion/q1w2e3r4t5';
+
+      expect(service.league).to.equal('Legion');
+    });
+
+    it('should returns the active league from a live search URL', () => {
+      window.location.pathname = '/trade/search/Legion/q1w2e3r4t5/live';
 
       expect(service.league).to.equal('Legion');
     });
@@ -65,6 +129,12 @@ describe('Unit | Services | TradeLocation', () => {
 
       expect(service.slug).to.equal('q1w2e3r4t5');
     });
+
+    it('should returns the active trade slug from a live search URL', () => {
+      window.location.pathname = '/trade/search/Legion/q1w2e3r4t5/live';
+
+      expect(service.slug).to.equal('q1w2e3r4t5');
+    });
   });
 
   describe('getTradeUrl', () => {
@@ -82,7 +152,7 @@ describe('Unit | Services | TradeLocation', () => {
       (service.locationPollingTask as Task).cancelAll();
     });
 
-    describe('when the location switch', () => {
+    describe(`when the location switches to a new trade`, () => {
       beforeEach(() => {
         window.location.pathname = '/trade/search/new-league/new-trade';
       });
@@ -95,6 +165,7 @@ describe('Unit | Services | TradeLocation', () => {
             type: 'search',
             slug: 'new-trade',
             league: 'new-league',
+            isLive: false,
           })
           .returns(Promise.resolve());
 
@@ -110,11 +181,55 @@ describe('Unit | Services | TradeLocation', () => {
             type: 'search',
             slug: 'initial-trade',
             league: 'initial-league',
+            isLive: false,
           },
           newTradeLocation: {
             type: 'search',
             slug: 'new-trade',
             league: 'new-league',
+            isLive: false,
+          },
+        });
+      });
+    });
+
+    describe(`when the location toggles to live search mode`, () => {
+      beforeEach(() => {
+        window.location.pathname = '/trade/search/initial-league/initial-trade/live';
+      });
+
+      it('should fires the event and log the history change', async () => {
+        // It's TradeLocationHistory's responsibility to ignore this case
+        tradeLocationHistoryMock
+          .expects('maybeLogTradeLocation')
+          .once()
+          .withArgs({
+            type: 'search',
+            slug: 'initial-trade',
+            league: 'initial-league',
+            isLive: true,
+          })
+          .returns(Promise.resolve());
+
+        const changeSpy = sinon.spy();
+        service.on('change', changeSpy);
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        (service.locationPollingTask as Task).perform();
+        await delay(150);
+
+        expect(changeSpy).to.have.been.calledOnceWith({
+          oldTradeLocation: {
+            type: 'search',
+            slug: 'initial-trade',
+            league: 'initial-league',
+            isLive: false,
+          },
+          newTradeLocation: {
+            type: 'search',
+            slug: 'initial-trade',
+            league: 'initial-league',
+            isLive: true,
           },
         });
       });

--- a/tests/unit/services/trade-location/history-test.ts
+++ b/tests/unit/services/trade-location/history-test.ts
@@ -9,6 +9,7 @@ import fakeTradeLocationHistory from 'better-trading/tests/fixtures/trade-locati
 
 // Types
 import TradeLocationHistory from 'better-trading/services/trade-location/history';
+import {TradeLocationStruct} from 'better-trading/types/trade-location';
 
 describe('Unit | Services | TradeLocation | History', () => {
   setupTest();
@@ -43,6 +44,22 @@ describe('Unit | Services | TradeLocation | History', () => {
       storageMock.expects('setValue').never();
 
       await service.maybeLogTradeLocation({slug: 'bang', league: 'foo', type: 'search'});
+    });
+
+    it('should not log it twice if it is identical to the last entry modulo liveness', async () => {
+      storageMock
+        .expects('getValue')
+        .once()
+        .returns(Promise.resolve([fakeTradeLocationHistory({slug: 'bang', league: 'foo', type: 'search'})]));
+
+      storageMock.expects('setValue').never();
+
+      await service.maybeLogTradeLocation({
+        slug: 'bang',
+        league: 'foo',
+        type: 'search',
+        isLive: true,
+      } as TradeLocationStruct);
     });
 
     it('should prepend a valid entry', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2017",
     "allowJs": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
@@ -22,7 +22,7 @@
     "module": "esNext",
     "lib": [
       "dom",
-      "es2019",
+      "es2017",
       "esnext.asynciterable"
     ],
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2019",
     "allowJs": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
@@ -22,7 +22,7 @@
     "module": "esNext",
     "lib": [
       "dom",
-      "es2017",
+      "es2019",
       "esnext.asynciterable"
     ],
     "paths": {


### PR DESCRIPTION
This PR implements the feature suggested in #71, auto-updating the page title for trade searches to include:

* A ⚡ icon to indicate whether it's a live search or not
* The title of the active bookmark, if the current trade is bookmarked
* An inferred trade title using the existing bookmark title recommender from `SearchPanel.recommendTitle()`, if the current trade is not bookmarked
* Fall back to the original page title (in English, `Trade - Path of Exile`) if we don't know how to recommend a title for an unbookmarked trade

![screenshot demonstrating above features](https://user-images.githubusercontent.com/376284/190880680-c7d3ccf0-3ee3-48fb-8171-5e509874f30d.png)

It implements this by:
* adding a new `PageTitle` service to contain the high level logic, maintain state about the title we're enforcing, and maintain a `MutationObserver` to counteract the base site's attempts to occasionally reset the page to its own default title
* updating the `TradeLocation` service to include info about whether the current trade is a live search or not
* updating the `Bookmarks` service to:
    * emit a `change` event when bookmarks are updated (this is imperfect since it won't catch a user renaming one tab's bookmark in a different tab, but we already don't catch this and update the bookmarks list itself when this happens, I think it's fine for this to require a refresh)
    * support a new `fetchTradeByLocation` operation
* updates tsconfig to target es2019 (to enable the use of `flatMap` in the `fetchTradeByLocation` implementation)

This isn't super efficient; it refetches every trade every time the trade location changes or any bookmark changes. My expectation is that this should be efficient-enough, since both of those events should only happen in response to direct user interaction, but it might be preferable to move the in-memory state of trades out of the `BookmarksFolder` component and into a service (either the `Bookmarks` service or a new one) to avoid the round trips to storage...

closes #71