### PR TITLE
Fixes #182 (Since 0.5, website layout is going below Better Trading window)

### DIFF
--- a/app/styles/globals/_base.scss
+++ b/app/styles/globals/_base.scss
@@ -1,7 +1,7 @@
 body.bt-body {
   overflow-y: scroll;
 
-  #app {
+  #trade {
     width: calc(100% - #{$extension-width});
     margin: 0;
     transition: width 0.2s ease;
@@ -21,7 +21,7 @@ body.bt-body {
   }
 
   &.bt-is-collapsed {
-    #app {
+    #trade {
       width: 100%;
     }
 


### PR DESCRIPTION
GGG changed their main Vue mount point from #app to #trade. The extension's layout CSS was targeting #app to shrink the page content when the panel is open, but since #app is now an empty div, the panel was rendering as a full-width overlay instead of pushing the content aside.
Changed the two #app selectors to #trade to restore the original side-by-side layout.